### PR TITLE
Add `metadata.namespace` to remaining Helm templates

### DIFF
--- a/kubecost/templates/aggregator/actions-config-configmap.yaml
+++ b/kubecost/templates/aggregator/actions-config-configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "kubecost.actions.configMapName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
 data:

--- a/kubecost/templates/aggregator/actions-store-secret.yaml
+++ b/kubecost/templates/aggregator/actions-store-secret.yaml
@@ -5,6 +5,7 @@ kind: Secret
 type: Opaque
 metadata:
   name: {{ .Release.Name }}-actions-storage-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
 data:

--- a/kubecost/templates/frontend/frontend-branding.yaml
+++ b/kubecost/templates/frontend/frontend-branding.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "kubecost.frontend.logoConfigMapName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
 binaryData:

--- a/kubecost/templates/install-plugins.yaml
+++ b/kubecost/templates/install-plugins.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "kubecost.fullname" . }}-install-plugins
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
 data:

--- a/kubecost/templates/kubecost-openshift-route.yaml
+++ b/kubecost/templates/kubecost-openshift-route.yaml
@@ -3,6 +3,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ include "kubecost.fullname" . }}-route
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
   {{- with .Values.global.platforms.openshift.route.annotations }}

--- a/kubecost/templates/kubecost-role-binding-template.yaml
+++ b/kubecost/templates/kubecost-role-binding-template.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ template "kubecost.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
 roleRef:

--- a/kubecost/templates/kubecost-role-template.yaml
+++ b/kubecost/templates/kubecost-role-template.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ template "kubecost.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
 rules:

--- a/kubecost/templates/plugins-config.yaml
+++ b/kubecost/templates/plugins-config.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.plugins.secretName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
 data:


### PR DESCRIPTION
## Release Notes Headline

N/A

## Commentary for Reviewers

This MR ensures all Helm templates include `metadata.namespace`. This is not only for consistency, but also for ArgoCD integration.

<img width="1016" height="240" alt="image" src="https://github.com/user-attachments/assets/fb8788c4-b853-4565-9252-afb87a99bcc1" />

## Links to Issues or Tickets

N/A

## User Impact and Risks

N/A

## Testing

N/A

## Documentation Updates

N/A