### PR TITLE
KCM-5409: add endpoint slices to the cluster role for kubecost network daemonset i.e v1/endpoint is deprecated

### DIFF
--- a/kubecost/templates/network-costs/network-costs-cluster-role.yaml
+++ b/kubecost/templates/network-costs/network-costs-cluster-role.yaml
@@ -17,6 +17,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - discovery.k8s.io
+    resources:
+      - endpointslices
+    verbs:
+      - get
+      - list
+      - watch
   {{- if .Values.networkCosts.leaderKubernetesWatcher }}
   - apiGroups:
       - coordination.k8s.io


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
Supports discovery.k8s.io/v1/EndpointSlice over v1/Endpoint when k8s version is >= 1.21
## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets
https://apptio.atlassian.net/browse/KCM-5409
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
No deprecated warnings in apiserver logs

I checked them using

```
>kubectl get --raw /metrics | grep apiserver_requested_deprecated_apis
```
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Refer the network daemonset PR https://github.com/kubecost/network-costs-rs/pull/158
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
