### PR TITLE
Move storageConfig and natGatewayConfig to k8s Secret

### DIFF
--- a/kubecost/templates/network-costs/network-costs-configmap.yaml
+++ b/kubecost/templates/network-costs/network-costs-configmap.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.networkCosts -}}
 {{- if .Values.networkCosts.enabled -}}
-{{- if or .Values.networkCosts.config .Values.networkCosts.storageConfig .Values.networkCosts.natGatewayConfig -}}
+{{- if .Values.networkCosts.config -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -9,18 +9,8 @@ metadata:
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
 data:
-{{- if .Values.networkCosts.config }}
   config.yaml: |
 {{ toYaml .Values.networkCosts.config | nindent 4 }}
-{{- end }}
-{{- if .Values.networkCosts.storageConfig }}
-  storage.yaml: |
-{{ toYaml .Values.networkCosts.storageConfig | nindent 4 }}
-{{- end }}
-{{- if .Values.networkCosts.natGatewayConfig }}
-  nat-gateway.yaml: |
-{{ toYaml .Values.networkCosts.natGatewayConfig | nindent 4 }}
-{{- end }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/kubecost/templates/network-costs/network-costs-daemonset.yaml
+++ b/kubecost/templates/network-costs/network-costs-daemonset.yaml
@@ -89,11 +89,11 @@ spec:
           value: {{ (quote .Values.networkCosts.conntrackRefreshInterval) }}
         {{- if .Values.networkCosts.storageConfig }}
         - name: STORAGE_CONFIG_PATH
-          value: /network-costs/config/storage.yaml
+          value: /network-costs/secret/storage.yaml
         {{- end }}
         {{- if .Values.networkCosts.natGatewayConfig }}
         - name: NAT_GATEWAY_CONFIG_PATH
-          value: /network-costs/config/nat-gateway.yaml
+          value: /network-costs/secret/nat-gateway.yaml
         {{- end }}
         {{- if .Values.networkCosts.healthCheckProbes }}
         {{- toYaml .Values.networkCosts.healthCheckProbes | nindent 8 }}
@@ -111,6 +111,10 @@ spec:
         {{- if .Values.networkCosts.config }}
         - mountPath: /network-costs/config
           name: network-costs-config
+        {{- end }}
+        {{- if or .Values.networkCosts.storageConfig .Values.networkCosts.natGatewayConfig }}
+        - mountPath: /network-costs/secret
+          name: network-costs-secret
         {{- end }}
         securityContext:
           privileged: true  # Required
@@ -140,6 +144,11 @@ spec:
       - name: network-costs-config
         configMap:
           name: network-costs-config
+      {{- end }}
+      {{- if or .Values.networkCosts.storageConfig .Values.networkCosts.natGatewayConfig }}
+      - name: network-costs-secret
+        secret:
+          secretName: network-costs-secret
       {{- end }}
       {{- if .Values.networkCosts.hostProc }}
       - name: host-proc

--- a/kubecost/templates/network-costs/network-costs-daemonset.yaml
+++ b/kubecost/templates/network-costs/network-costs-daemonset.yaml
@@ -115,6 +115,7 @@ spec:
         {{- if or .Values.networkCosts.storageConfig .Values.networkCosts.natGatewayConfig }}
         - mountPath: /network-costs/secret
           name: network-costs-secret
+          readOnly: true
         {{- end }}
         securityContext:
           privileged: true  # Required

--- a/kubecost/templates/network-costs/network-costs-secret.yaml
+++ b/kubecost/templates/network-costs/network-costs-secret.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.networkCosts -}}
+{{- if .Values.networkCosts.enabled -}}
+{{- if or .Values.networkCosts.storageConfig .Values.networkCosts.natGatewayConfig -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: network-costs-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubecost.commonLabels" . | nindent 4 }}
+type: Opaque
+stringData:
+{{- if .Values.networkCosts.storageConfig }}
+  storage.yaml: |
+{{ toYaml .Values.networkCosts.storageConfig | nindent 4 }}
+{{- end }}
+{{- if .Values.networkCosts.natGatewayConfig }}
+  nat-gateway.yaml: |
+{{ toYaml .Values.networkCosts.natGatewayConfig | nindent 4 }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
## Release Notes Headline

Move `storageConfig` and `natGatewayConfig` from a ConfigMap to a Kubernetes Secret to protect sensitive credentials (access keys, secret keys).

## Commentary for Reviewers

Builds on [#4541](https://github.com/kubecost/kubecost/pull/4541), which introduced `storageConfig` and `natGatewayConfig` as ConfigMap entries. Both fields can contain AWS access/secret keys, so they belong in a Secret.

## Links to Issues or Tickets

- Follows up on #4541 (NAT Gateway config via ConfigMap)
- Ref: https://github.com/kubecost/network-costs-rs/blob/develop/docs/nat-gateway.md

## User Impact and Risks

- **Opt-in only.** Both `storageConfig` and `natGatewayConfig` default to `{}`. Existing deployments without these values set are unaffected.
## Testing

**Setup:**

```sh
rm -rf ./kubecost/charts
helm repo add finops-agent https://kubecost.github.io/finops-agent-chart/
helm repo update finops-agent
helm dependency build ./kubecost
```

<details>
<summary><strong>Test 1: Default values (no storageConfig / natGatewayConfig)</strong></summary>

```sh
helm template kubecost ./kubecost
```

Results:

- ConfigMap `network-costs-config` renders with only `config.yaml`. No `storage.yaml` or `nat-gateway.yaml` keys present.
- No `network-costs-secret` Secret is rendered.
- DaemonSet has no `/network-costs/secret` volumeMount or secret volume.
- `STORAGE_CONFIG_PATH` and `NAT_GATEWAY_CONFIG_PATH` env vars are absent. Backwards compatible. ✅

</details>

<details>
<summary><strong>Test 2: With storageConfig and natGatewayConfig set</strong></summary>

```sh
helm template kubecost ./kubecost \
  --set 'networkCosts.enabled=true' \
  --set-json 'networkCosts.storageConfig={"type":"S3","config":{"bucket":"kc-net-costs-flow-logs","access_key":"REDACTED","secret_key":"REDACTED"}}' \
  --set-json 'networkCosts.natGatewayConfig={"enabled":true,"aws":{"cluster-name":"qa-eks3","access_key":"REDACTED","secret_key":"REDACTED","aws_sdk_auth":false},"refresh-interval":"10m"}'
```

Results:

- Secret `network-costs-secret` renders with `storage.yaml` and `nat-gateway.yaml` containing the credentials (type `Opaque`, `stringData`).
- ConfigMap `network-costs-config` renders only `config.yaml` (no credential keys).
- DaemonSet env vars:
  ```
  - name: STORAGE_CONFIG_PATH
    value: /network-costs/secret/storage.yaml
  - name: NAT_GATEWAY_CONFIG_PATH
    value: /network-costs/secret/nat-gateway.yaml
  ```
- DaemonSet volumeMount at `/network-costs/secret` backed by `network-costs-secret` Secret.
- Output is valid Kubernetes YAML. ✅

</details>

## Documentation Updates

N/A (values.yaml comments serve as inline documentation).
