### PR TITLE
NAT Gateway: option to use federatedStorage

### DIFF
--- a/kubecost/templates/network-costs/network-costs-daemonset.yaml
+++ b/kubecost/templates/network-costs/network-costs-daemonset.yaml
@@ -90,6 +90,9 @@ spec:
         {{- if .Values.networkCosts.storageConfig }}
         - name: STORAGE_CONFIG_PATH
           value: /network-costs/config/storage.yaml
+        {{- else if or (.Values.global.federatedStorage).config (.Values.global.federatedStorage).existingSecret }}
+        - name: STORAGE_CONFIG_PATH
+          value: /network-costs/federated-store/{{ include "kubecost.federatedStorage.fileName" . }}
         {{- end }}
         {{- if .Values.networkCosts.natGatewayConfig }}
         - name: NAT_GATEWAY_CONFIG_PATH
@@ -111,6 +114,11 @@ spec:
         {{- if .Values.networkCosts.config }}
         - mountPath: /network-costs/config
           name: network-costs-config
+        {{- end }}
+        {{- if and (not .Values.networkCosts.storageConfig) (or (.Values.global.federatedStorage).config (.Values.global.federatedStorage).existingSecret) }}
+        - mountPath: /network-costs/federated-store
+          name: network-costs-federated-store
+          readOnly: true
         {{- end }}
         securityContext:
           privileged: true  # Required
@@ -140,6 +148,11 @@ spec:
       - name: network-costs-config
         configMap:
           name: network-costs-config
+      {{- end }}
+      {{- if and (not .Values.networkCosts.storageConfig) (or (.Values.global.federatedStorage).config (.Values.global.federatedStorage).existingSecret) }}
+      - name: network-costs-federated-store
+        secret:
+          secretName: {{ include "kubecost.federatedStorage.secretName" . | trim }}
       {{- end }}
       {{- if .Values.networkCosts.hostProc }}
       - name: host-proc

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -861,6 +861,9 @@ networkCosts:
 
   ## Storage configuration for NAT gateway traffic logs
   ## Used when NAT gateway traffic detection is enabled to access VPC flow logs
+  ## Note: when set, storageConfig takes priority over global.federatedStorage for
+  ## the STORAGE_CONFIG_PATH env var in the network-costs DaemonSet. If both are
+  ## configured, global.federatedStorage will be ignored for network-costs.
   ## Example for S3:
   ##   storageConfig:
   ##     type: S3


### PR DESCRIPTION
## Release Notes Headline

Allow network-costs to fall back to `global.federatedStorage` for `STORAGE_CONFIG_PATH` when `networkCosts.storageConfig` is not set.

## Commentary for Reviewers

As titled.

## Links to Issues or Tickets

- https://apptio.atlassian.net/browse/KCM-5885
- Related to https://github.com/kubecost/kubecost/pull/4541
- Related to https://github.com/kubecost/kubecost/pull/4718

## User Impact and Risks

N/A

## Testing

<details>
<summary>Test: helm template with default values (no storageConfig, no federatedStorage)</summary>

```sh
rm -rf ./kubecost/charts
helm repo add finops-agent https://kubecost.github.io/finops-agent-chart/
helm repo update finops-agent
helm dependency build ./kubecost
helm template kubecost ./kubecost
```

Verified by grepping the rendered DaemonSet for `STORAGE_CONFIG_PATH`, `federated-store`, and `network-costs-secret`:

```
$ helm template kubecost ./kubecost | grep -A 200 "kind: DaemonSet" \
    | grep -E "STORAGE_CONFIG_PATH|federated-store|network-costs-secret"
(no output)
```

Neither `STORAGE_CONFIG_PATH` nor any `federated-store` volume or mount appears in the DaemonSet. Output is valid Kubernetes YAML. **PASS.**

</details>

<details>
<summary>Test: helm template with networkCosts.storageConfig set (priority path)</summary>

```sh
helm template kubecost ./kubecost \
  --set networkCosts.enabled=true \
  --set-json 'networkCosts.storageConfig={"type":"S3","config":{"bucket":"my-bucket"}}'
```

Relevant DaemonSet output:

```yaml
- name: STORAGE_CONFIG_PATH
  value: /network-costs/secret/storage.yaml
```

No `network-costs-federated-store` volume or mount is present. `storageConfig` takes priority as expected; the federated-store fallback branch is not entered. **PASS.**

</details>

<details>
<summary>Test: helm template with global.federatedStorage.config set and no storageConfig (fallback path)</summary>

```sh
helm template kubecost ./kubecost \
  --set networkCosts.enabled=true \
  --set global.federatedStorage.config="dHlwZTogUzMK"
```

Relevant DaemonSet output:

```yaml
# env
- name: STORAGE_CONFIG_PATH
  value: /network-costs/federated-store/federated-store.yaml

# volumeMounts
- mountPath: /network-costs/federated-store
  name: network-costs-federated-store
  readOnly: true

# volumes
- name: network-costs-federated-store
  secret:
    secretName: kubecost-federated-storage-config
```

`STORAGE_CONFIG_PATH` resolves to the correct path via the `kubecost.federatedStorage.fileName` helper (`federated-store.yaml`). The volume is backed by the `kubecost-federated-storage-config` Secret (resolved via `kubecost.federatedStorage.secretName`). No `network-costs-secret` volume is injected (neither `storageConfig` nor `natGatewayConfig` is set). **PASS.**

</details>

## Documentation Updates

Priority behavior documented inline in `values.yaml` above the `networkCosts.storageConfig` field.