### PR TITLE
Bump images and chart version for 2.9.7

### DIFF
--- a/cost-analyzer/Chart.lock
+++ b/cost-analyzer/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: finops-agent
   repository: https://kubecost.github.io/finops-agent-chart
-  version: 1.0.8
-digest: sha256:c2937de35278e73d6575847bcbf6d974e00ec00491b801a0cb766e4d26fd500c
-generated: "2026-01-16T21:35:30.98577+05:30"
+  version: 1.0.20
+digest: sha256:316ce61c49a6a89a65aaf7d843e7cf0455d584eb6c05e37ca20b2f5c88c6a048
+generated: "2026-06-25T10:27:45.397979-05:00"

--- a/cost-analyzer/Chart.yaml
+++ b/cost-analyzer/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "2.9.6"
+appVersion: "2.9.7"
 description: Kubecost Helm chart - monitor your cloud costs!
 name: cost-analyzer
-version: "2.9.6"
+version: "2.9.7"
 icon: https://raw.githubusercontent.com/kubecost/.github/9602bea0c06773da66ba43cb9ce5e1eb2b797c32/kubecost_logo.png
 annotations:
   "artifacthub.io/links": |
@@ -11,6 +11,6 @@ annotations:
 dependencies:
   - name: finops-agent
     alias: finopsagent
-    version: "v1.0.8"
+    version: "v1.0.20"
     repository: https://kubecost.github.io/finops-agent-chart
     condition: finopsagent.enabled

--- a/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
+++ b/cost-analyzer/templates/cost-analyzer-frontend-config-map-template.yaml
@@ -1631,7 +1631,7 @@ data:
                 "carbonEstimatesEnabled": "{{ template "carbonEstimatesEnabled" . }}",
                 "clusterControllerEnabled": "{{ template "clusterControllerEnabled" . }}",
                 "forecastingEnabled": "{{ template "forecastingEnabled" . }}",
-                "chartVersion": "2.9.6",
+                "chartVersion": "2.9.7",
                 "hourlyDataRetention": "{{ (.Values.kubecostAggregator.etlHourlyStoreDurationHours) }}",
                 "dailyDataRetention": "{{ (.Values.kubecostAggregator.etlDailyStoreDurationDays) }}",
                 "hideDiagnostics": "{{ default false ((.Values.kubecostProductConfigs).hideDiagnostics) }}",


### PR DESCRIPTION
Release Notes Headline
Bump chart version and finops-agent to v1.0.20 for v2.9.7 release.

Commentary for Reviewers
Bumps Chart.yaml, Chart.lock, and frontend config map to v2.9.7. Updates finops-agent dependency from v1.0.8 to v1.0.20.

Links to Issues or Tickets
N/A

User Impact and Risks
Low risk. Helm-only changes.

Testing
Will verify by triggering the release workflow after merge.

Documentation Updates
N/A
