### PR TITLE
Fix: Add Helm labels to OpenShift SCC templates so they are properly tracked and deleted on uninstall

### DIFF
--- a/kubecost/templates/cluster-controller/cluster-controller-ocp-scc.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-ocp-scc.yaml
@@ -3,6 +3,8 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   name: {{ include "kubecost.clusterController.name" . }}
+  labels:
+    {{- include "kubecost.commonLabels" . | nindent 4 }}
 priority: 10
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true

--- a/kubecost/templates/network-costs/networks-costs-ocp-scc.yaml
+++ b/kubecost/templates/network-costs/networks-costs-ocp-scc.yaml
@@ -3,6 +3,8 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   name: {{ template "kubecost.networkCosts.name" . }}
+  labels:
+    {{- include "kubecost.commonLabels" . | nindent 4 }}
 priority: 10
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true


### PR DESCRIPTION


## Links to Issues or Tickets

https://github.com/kubecost/operators/pull/68

