### PR TITLE
Change Aggregator.retention10m to 0

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -991,8 +991,9 @@ aggregator:
 
   ## Retention values determine for what duration into the past data will be
   ## ingested into Aggregator's database. 10m resolution data is only used for the
-  ## Node rightsizing and Resource Quota rightsizing features for further granularity.
-  ## Enabling 10m data will increase resource usage of the aggregator. A good starting value is 36.
+  ## Node Group Right-Sizing and Resource Quota Right-Sizing features for further
+  ## granularity. Enabling 10m data will increase resource usage of the Aggregator.
+  ## A good starting value would be `retention10m: 36`
   retention1d: 91
   retention1h: 49
   retention10m: 0

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -994,7 +994,7 @@ aggregator:
   retention1d: 91
   retention1h: 49
   # 10m files are currently only use for specific right sizing operations. Enabling 10m data will increase resource usage of the aggregator.
-  retention10m: 0 
+  retention10m: 0
 
   # Replicas sets the number of Aggregator replicas.
   replicas: 1

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -990,8 +990,8 @@ aggregator:
   imagePullPolicy: IfNotPresent
 
   ## Retention values determine for what duration into the past data will be
-  ## ingested into Aggregator's database. 10m resolution data is only used for the 
-  ## Node rightsizing and Resource Quota rightsizing features for further granularity. 
+  ## ingested into Aggregator's database. 10m resolution data is only used for the
+  ## Node rightsizing and Resource Quota rightsizing features for further granularity.
   ## Enabling 10m data will increase resource usage of the aggregator. A good starting value is 36.
   retention1d: 91
   retention1h: 49

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -993,7 +993,8 @@ aggregator:
   ## ingested into Aggregator's database
   retention1d: 91
   retention1h: 49
-  retention10m: 36
+  # 10m files are currently only use for specific right sizing operations. Enabling 10m data will increase resource usage of the aggregator.
+  retention10m: 0 
 
   # Replicas sets the number of Aggregator replicas.
   replicas: 1

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -990,10 +990,11 @@ aggregator:
   imagePullPolicy: IfNotPresent
 
   ## Retention values determine for what duration into the past data will be
-  ## ingested into Aggregator's database
+  ## ingested into Aggregator's database. 10m resolution data is only used for the 
+  ## Node rightsizing and Resource Quota rightsizing features for further granularity. 
+  ## Enabling 10m data will increase resource usage of the aggregator. A good starting value is 36.
   retention1d: 91
   retention1h: 49
-  # 10m files are currently only use for specific right sizing operations. Enabling 10m data will increase resource usage of the aggregator.
   retention10m: 0
 
   # Replicas sets the number of Aggregator replicas.


### PR DESCRIPTION
## Release Notes Headline

Changing Aggregator.retention10m = 0 to disable 10m files from being ingested into the aggregator by default

## Commentary for Reviewers

This is done to help improve efficiency of the aggregator and decrease resource usage especially for customers of scale. Large scale customers can expect to see large improvements in the aggregator's performance. This will also help to alleviate the number of clickhouse memory overcommit errors by proxy. 

## Links to Issues or Tickets

[https://apptio.atlassian.net/browse/KCM-5520](https://apptio.atlassian.net/browse/KCM-5520
)
[Slack Thread](https://kubecost.slack.com/archives/C0BDABS696X/p1782735733658409)
## User Impact and Risks

The Risks for this PR is that by default the request right sizing will not work with a view of last 48 hours. This is the only screen that currently uses the 10m data.

## Testing

This change has been a recommended configuration change for many large scale environments who have all seen a noticeable improvement in performance and data integrity.

## Documentation Updates

Section will need to be added to the Resource rightsizing page highlighting the need for changing retention 10m if they intend to use rightsizing with a last 48 hours view.
