### PR TITLE
feat(cloud-cost): expose AZURE_DOWNLOAD_BILLING_DATA_TO_DISK

### DIFF
--- a/kubecost/templates/cloud-cost/cloud-cost-deployment.yaml
+++ b/kubecost/templates/cloud-cost/cloud-cost-deployment.yaml
@@ -253,6 +253,8 @@ spec:
               value: {{ .Values.cloudCost.queryWindowDays | default 7 | quote }}
             - name: CLOUD_COST_RUN_WINDOW_DAYS
               value: {{ .Values.cloudCost.runWindowDays | default 3 | quote }}
+            - name: AZURE_DOWNLOAD_BILLING_DATA_TO_DISK
+              value: {{ .Values.cloudCost.downloadBillingDataToDisk | default false | quote }}
             - name: CUSTOM_COST_ENABLED
               value: {{ .Values.plugins.enabled | quote }}
             - name: LOG_LEVEL

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1239,6 +1239,19 @@ cloudCost:
   ## queried and processed into ETL.
   retention1d: 91
 
+  ## Azure integrations only. Controls whether the Azure billing export is written to disk before
+  ## being parsed, or streamed directly from blob storage.
+  ##
+  ## When false (default), the export is streamed and parsed in a bounded buffer, and nothing is
+  ## written to the persistentConfigs volume. When true, each export is downloaded to
+  ## <CONFIG_PATH>/db/cloudcost first. Azure names every export run with a distinct timestamp and
+  ## GUID, so successive runs accumulate as separate files rather than overwriting, and a
+  ## month-to-date export for a large subscription can exhaust the persistentConfigs volume.
+  ##
+  ## Only set this to true if you have a specific reason to keep the exports on disk, and size
+  ## cloudCost.persistentConfigsStorage accordingly.
+  downloadBillingDataToDisk: false
+
   ## Specify an existing Kubernetes Secret holding the cloud integration information. This Secret must contain
   ## a key with name `cloud-integration.json` and the contents must be in a specific format. It is expected
   ## to exist in the release Namespace. This is mutually exclusive with cloudIntegrationJSON where only one must be defined.


### PR DESCRIPTION
## Release Notes Headline

Azure billing exports are now streamed rather than written to the cloudCost pod's persistentConfigs volume, configurable via `cloudCost.downloadBillingDataToDisk`.

## Commentary for Reviewers

The Azure billing parser is the only cloud integration that stages billing data on local disk before parsing it. It writes each export to `<CONFIG_PATH>/db/cloudcost`, which resolves to the cloudCost pod's `persistentConfigs` volume — the volume this chart documents as holding *"settings and configurations created via the UI"* and defaults to **1Gi**.

Azure names every export run with a distinct run timestamp and GUID, so successive runs land at new paths and accumulate rather than overwriting. A month-to-date export for a large subscription therefore fills the volume:

```
CloudCost: Azure: DownloadBlobToFile: failed to download write
/var/configs/db/cloudcost/azamortizedcost_..._000019.csv: no space left on device
```

For contrast, AWS buffers the CUR in memory and GCP queries BigQuery; neither touches disk.

The cost-model already supports parsing the export as a **stream** instead — a bounded double buffer, ~2 x 8MB per blob regardless of export size, writing nothing to disk. That path existed but was only reachable via `cloudCost.extraEnv`.

This PR exposes it as a first-class value, `cloudCost.downloadBillingDataToDisk`.

Two notes for reviewers:

1. **It is added only to the cloudCost deployment.** `cloudcost.Initialize` has exactly one caller (`pkg/cmd/cloudcost/cloudcost.go`), so the aggregator never runs the Azure billing parser and does not need the variable.
2. **Default choice.** This defaults to `false`, which changes behaviour on upgrade for Azure users. That is deliberate: it fixes the volume exhaustion on currently-released images without waiting for an upstream release. If you would rather the chart only expose the knob and leave the default to the binary, the template can render the variable only when the key is explicitly set — happy to change it.

Related upstream PR: opencost/opencost#3981 flips the same default in the cost-model itself. Once that lands and ships, this chart value becomes belt-and-braces rather than the mechanism. **This PR does not depend on it** and can merge independently. opencost/opencost#3980 separately fixes partial-file corruption on the download-to-disk path, which still matters for anyone who sets this to `true`.

## Links to Issues or Tickets

N/A

## User Impact and Risks

**Impact.** Azure billing exports are streamed and parsed in a bounded buffer; nothing is written to `<CONFIG_PATH>/db/cloudcost`. Existing files there are left in place — they are no longer read and can be deleted to reclaim space.

Memory is bounded at roughly two 8MB blocks per blob regardless of export size, so this is not a disk-for-memory trade.

**Risks.**

- Behaviour change on upgrade for Azure users. Mitigated by `cloudCost.downloadBillingDataToDisk: true`, which restores the previous behaviour exactly.
- Streaming re-reads the blob each ingestion cycle rather than reusing a local copy, so slightly more egress and API calls. In practice the local copy was rarely reused — each export run has a new timestamp and GUID in its name, so the destination path was almost always new and the existing modification-time check did not hit.
- Non-Azure integrations are unaffected; the variable is read only by the Azure billing parser.
- No change for users who do not enable `cloudCost`.

## Testing

`helm template` against the cloud-cost deployment, verifying the rendered env var in every case:

| values | renders |
|---|---|
| unset (chart default) | `value: "false"` |
| `--set cloudCost.downloadBillingDataToDisk=true` | `value: "true"` |
| `--set cloudCost.downloadBillingDataToDisk=false` | `value: "false"` |
| `--set cloudCost.downloadBillingDataToDisk=null` | `value: "false"` |

The `null` case covers an existing user values file that omits the key; `| default false` keeps it safe rather than rendering an empty string.

`helm lint .` — 1 chart linted, 0 failed.

## Documentation Updates

The new value is documented inline in `values.yaml`, including why the default is `false` and what to do if you set it to `true` (size `cloudCost.persistentConfigsStorage` accordingly). Happy to raise a docs PR if the Azure integration page should call this out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)