### PR TITLE
Bump Aggregator terminationGracePeriodSeconds to 180s

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1004,8 +1004,10 @@ aggregator:
   # Replicas sets the number of Aggregator replicas.
   replicas: 1
 
-  # terminationGracePeriodSeconds sets the pod termination grace period for the aggregator StatefulSet.
-  terminationGracePeriodSeconds: 90
+  ## Sets the pod termination grace period for the Aggregator StatefulSet. Must
+  ## exceed shutdown_wait_unfinished (120s in kc-embedded-ch-config.xml) plus
+  ## app drain time.
+  terminationGracePeriodSeconds: 180
 
   # Log level for the aggregator container. Options are "trace", "debug", "info", "warn", "error", "fatal", "panic"
   logLevel: info


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
N/A

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->
As titled

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
- Partially addresses https://apptio.atlassian.net/browse/KCM-5022
- Related to https://github.com/kubecost/kubecost/pull/4726

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
Users may need to wait **up to** 3minutes (180s) for the Aggregator pod to fully terminate. However it is likely that the processes within the Aggregator container will handle the SIGTERM much more quickly than that allotted time.

## Testing

<!-- Describe the testing that was performed to verify the changes. -->
N/A

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
In `values.yaml`
