### PR TITLE
CLDYCON-7666 - Telemetry Auto-Consent

### DIFF
--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -586,6 +586,10 @@ spec:
               value: {{ .Release.Namespace }}
             - name: TELEMETRY_ENABLED
               value: {{ (quote .Values.telemetry.enabled) }}
+            {{- if .Values.telemetry.autoConsent }}
+            - name: TELEMETRY_AUTO_CONSENT
+              value: "true"
+            {{- end }}
             {{- if .Values.oidc.enabled }}
             - name: OIDC_ENABLED
               value: "true"

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1525,6 +1525,10 @@ costEventsAudit:
 ##
 telemetry:
   enabled: true
+  ## When true, telemetry consent is granted automatically at startup instead of
+  ## requiring a user action in the Settings UI. Defaults to false, so consent
+  ## stays user-driven unless explicitly enabled.
+  autoConsent: false
 
 ## These configs can also be set from the Settings page in the Kubecost product
 ## UI. Values in this block override config changes in the Settings UI on pod


### PR DESCRIPTION
## Release Notes Headline
* Telemetry can now be auto-consented via Helm values.

## Commentary for Reviewers
* Adds a new Helm value to enable the env var introduced by https://github.com/kubecost/kubecost-cost-model/pull/4738.

## Links to Issues or Tickets
* [CLDYCON-7666](https://apptio.atlassian.net/browse/CLDYCON-7666).

## User Impact and Risks
* Most users will be unaffected, unless they choose to enable this value, in which case they won't see a telemetry consent prompt in the UI.

## Testing
* Unit tests.


[CLDYCON-7666]: https://apptio.atlassian.net/browse/CLDYCON-7666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ