### PR TITLE
Fix cherry-pick workflow to use Github App Tokens.

### DIFF
--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -1,4 +1,4 @@
-name: Cherrypick labeled PR commits from "develop" into the corresponding release branch
+name: Cherry-pick to release branch
 on:
   pull_request_target:
     types: [closed]
@@ -11,35 +11,41 @@ permissions:
 
 jobs:
   cherrypick:
-    name: Cherrypick to release branch
     runs-on: ubuntu-latest
-    # Only run when a PR is merged or a comment `/backport` is created.
+    # A labeled PR was merged, or someone commented `/backport` on one.
     if: >
-      (
-        github.event_name == 'pull_request_target' && github.event.pull_request.merged == true
-      ) || (
-        github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.comment.body == '/backport'
-      )
+      github.event.pull_request.merged || (github.event.issue.pull_request &&
+      github.event.comment.body == '/backport')
     steps:
-      - name: Checkout Repo
+      - name: Checkout kubecost
         uses: actions/checkout@v6
 
-      - name: Check out actions code
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.KC_ACTIONS_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.KC_ACTIONS_BOT_APP_PRIVATE_KEY }}
+          owner: kubecost
+          repositories: github-actions
+
+      - name: Checkout github-actions
         uses: actions/checkout@v6
         with:
           repository: kubecost/github-actions
           path: ./github-actions
           ref: main
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
 
-      - name: Create cherrypick PR
+      - name: Cherry-pick
         uses: ./github-actions/backport-action
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           label_pattern: '^(v[0-9]+\.[0-9]+)$'
-          pull_description: 'Cherrypick of #${pull_number} to `${target_branch}`'
-          pull_title: ':cherries: ${pull_title} to ${target_branch}'
+          pull_title: ":cherries: ${pull_title} to ${target_branch}"
+          pull_description:
+            "Cherrypick of #${pull_number} to `${target_branch}`"
+          branch_name: "cherry-pick/${pull_number}-to-${target_branch}"
           add_labels: cherry-pick
-          branch_name: 'cherry-pick/${pull_number}-to-${target_branch}'
           merge_commits: fail
           cherry_picking: auto

--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -15,11 +15,20 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.KC_ACTIONS_BOT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.KC_ACTIONS_BOT_APP_PRIVATE_KEY }}
+          owner: kubecost
+          repositories: github-actions
+
       - name: Checkout github-actions
         uses: actions/checkout@v6
         with:
           repository: kubecost/github-actions
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           path: .github-actions
           sparse-checkout: lychee-action
 


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
Fix cherry-pick workflow to use Github App Tokens.

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->
Intended to resolve the following issue

<img width="1362" height="737" alt="Screenshot 2026-08-07 at 3 08 17 PM" src="https://github.com/user-attachments/assets/8758434b-c417-40c8-86fc-50407090254a" />

List of failed cherry-pick runs shown [here](https://github.com/kubecost/kubecost/actions/workflows/cherry-pick.yaml). This uses Github App Tokens, which is already being done in another workflow here https://github.com/kubecost/kubecost/blob/develop/.github/workflows/check_pr_labels.yaml

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->
N/A

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->
N/A

## Testing

<!-- Describe the testing that was performed to verify the changes. -->
N/A

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
N/A
