### PR TITLE
Bump default image versions

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -742,7 +742,7 @@ networkCosts:
   image:
     registry: ""  # Default is "icr.io"
     repository: kubecost/network-costs
-    tag: v0.19.0
+    tag: v0.19.1
   imagePullPolicy: IfNotPresent
 
   updateStrategy:
@@ -943,7 +943,7 @@ forecasting:
   image:
     registry: ""  # Default is "icr.io"
     repository: kubecost/modeling
-    tag: v0.1.36
+    tag: v0.2.0
   imagePullPolicy: IfNotPresent
 
   # Resource specification block for the forecasting container.
@@ -1393,7 +1393,7 @@ clusterController:
   image:
     registry: ""  # Default is "icr.io"
     repository: kubecost/cluster-controller
-    tag: v0.16.37
+    tag: v0.16.38
   imagePullPolicy: IfNotPresent
   logLevel: info
   extraEnv: []


### PR DESCRIPTION
Bump default image references for cluster-controller, network-costs, and kubecost-modeling.

## Release Notes Headline

Bump default image versions for:

* `network-costs`: `v0.19.0` -> `v0.19.1`
* `cluster-controller`: `v0.16.37` -> `v0.16.38`
* `kubecost-modeling`: `v0.1.36` -> `v0.2.0`

The reason for the `minor` bump in modeling is that HTTP status codes for some responses has changed.

## Commentary for Reviewers

Just pointing at all the latest versions before we release.

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
