### PR TITLE
fix(rbac): append Release.Namespace to ClusterRole/ClusterRoleBinding names (KCM-6116)

### DIFF
--- a/kubecost/templates/cluster-controller/cluster-controller-cluster-role-binding.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-cluster-role-binding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kubecost.clusterController.name" . }}
+  name: {{ include "kubecost.clusterController.name" . }}-{{ .Release.Namespace }}
   labels:
       {{- include "kubecost.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kubecost.clusterController.name" . }}
+  name: {{ include "kubecost.clusterController.name" . }}-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "kubecost.clusterController.name" . }}

--- a/kubecost/templates/cluster-controller/cluster-controller-cluster-role.yaml
+++ b/kubecost/templates/cluster-controller/cluster-controller-cluster-role.yaml
@@ -7,7 +7,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kubecost.clusterController.name" . }}
+  name: {{ include "kubecost.clusterController.name" . }}-{{ .Release.Namespace }}
   labels:
       {{- include "kubecost.commonLabels" . | nindent 4 }}
 rules:

--- a/kubecost/templates/network-costs/network-costs-cluster-role-binding.yaml
+++ b/kubecost/templates/network-costs/network-costs-cluster-role-binding.yaml
@@ -2,13 +2,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "kubecost.networkCosts.name" . }}-network-costs-cluster-role
+  name: {{ template "kubecost.networkCosts.name" . }}-network-costs-cluster-role-{{ .Release.Namespace }}
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "kubecost.networkCosts.name" . }}-network-costs-cluster-role
+  name: {{ template "kubecost.networkCosts.name" . }}-network-costs-cluster-role-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ template "kubecost.networkCosts.name" . }}

--- a/kubecost/templates/network-costs/network-costs-cluster-role.yaml
+++ b/kubecost/templates/network-costs/network-costs-cluster-role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "kubecost.networkCosts.name" . }}-network-costs-cluster-role
+  name: {{ template "kubecost.networkCosts.name" . }}-network-costs-cluster-role-{{ .Release.Namespace }}
   labels:
     {{- include "kubecost.commonLabels" . | nindent 4 }}
 rules:


### PR DESCRIPTION
fix(rbac): append Release.Namespace to ClusterRole/ClusterRoleBinding names (KCM-6116)

ClusterRole and ClusterRoleBinding names for network-costs and cluster-controller were derived solely from .Release.Name, causing name collisions when two Kubecost installs existed in different namespaces with the same release name.

Append .Release.Namespace to all four cluster-scoped resource names so each install produces a unique ClusterRole/ClusterRoleBinding.

BREAKING CHANGE: existing ClusterRole and ClusterRoleBinding resources will be renamed on upgrade. Delete the old resources before upgrading or use --force. Related to KCM-4812, KCM-6116.

## Release Notes Headline

ClusterRole and ClusterRoleBinding names for network-costs and cluster-controller now include the release namespace to prevent collisions across multi-namespace installs.

## Commentary for Reviewers

Four files changed — only the `metadata.name` and `roleRef.name` fields on the cluster-scoped resources. ServiceAccount names, helper templates, and all other manifests are untouched. The `roleRef.name` in each binding was updated to match the renamed ClusterRole so the binding remains valid.

## Links to Issues or Tickets

Closes KCM-6116
Ref KCM-4812

## User Impact and Risks

**Breaking change.** The ClusterRole and ClusterRoleBinding resources for `network-costs` and `cluster-controller` will be renamed on upgrade (e.g. `kubecost-cluster-controller` → `kubecost-cluster-controller-<namespace>`). Helm will attempt to create new resources while the old ones still exist. Before upgrading, manually delete the four old cluster-scoped resources or run `helm upgrade --force`.

## Testing

Validated with `helm template kubecost ./kubecost`. All four renamed resources render correctly with the namespace suffix, and each ClusterRoleBinding's `roleRef.name` matches its corresponding ClusterRole.

## Documentation Updates

N/A