### PR TITLE
Add mcp-kubecost subchart

### DIFF
--- a/.bob/rules/github-actions.md
+++ b/.bob/rules/github-actions.md
@@ -1,0 +1,10 @@
+## GitHub Actions Version Management
+
+- MUST verify a GitHub Action version exists before updating or downgrading it
+- MUST use execute_command to validate versions online: 
+  `curl -s https://api.github.com/repos/<owner>/<repo>/git/refs/tags | grep '"ref"' | grep '@v<N>'`
+- Or check the GitHub Marketplace page directly
+- NEVER assume a version does not exist based on training knowledge alone
+- When modifying any GitHub Action, MUST verify that all actions in the workflow are current
+- MUST use online lookups—do not depend on stale training data
+- If a new version is available, always suggest updating it

--- a/.github/scripts/validate_mcp_subchart.sh
+++ b/.github/scripts/validate_mcp_subchart.sh
@@ -109,7 +109,7 @@ assert_eq "${chart_lock} pins the same version as ${chart_yaml}" \
   "${dep_version#v}" "${lock_version#v}"
 
 default_enabled="$(yq -r ".[\"${values_key}\"].enabled" "${CHART_DIR}/values.yaml")"
-assert_eq "values.yaml defaults ${values_key}.enabled to false" "false" "$default_enabled"
+assert_eq "values.yaml defaults ${values_key}.enabled to true" "true" "$default_enabled"
 
 # ---------------------------------------------------------------------------
 group "Dependency resolution (validates Chart.lock is in sync)"
@@ -145,9 +145,9 @@ helm lint "$CHART_DIR" "${skip_schema[@]}" --set "${values_key}.enabled=true"
 pass "helm lint (--set ${values_key}.enabled=true)"
 
 # ---------------------------------------------------------------------------
-group "Subchart is opt-in"
+group "Subchart is enabled by default"
 
-helm template "$RELEASE_NAME" "$CHART_DIR" > "${RENDER_DIR}/default.yaml"
+helm template "$RELEASE_NAME" "$CHART_DIR" "${skip_schema[@]}" > "${RENDER_DIR}/default.yaml"
 pass "helm template (defaults) rendered without errors"
 
 # Only look at rendered resource sources, since the diagnostics ConfigMap
@@ -155,9 +155,9 @@ pass "helm template (defaults) rendered without errors"
 default_sources="$(grep '^# Source:' "${RENDER_DIR}/default.yaml" || true)"
 # Helm uses the alias (when set) as the on-disk chart directory in # Source: lines.
 if printf '%s\n' "$default_sources" | grep -q "charts/${values_key}/"; then
-  fail "subchart rendered resources while ${values_key}.enabled=false"
+  pass "subchart resources rendered with ${values_key}.enabled=true (default)"
 else
-  pass "no subchart resources rendered while ${values_key}.enabled=false"
+  fail "subchart rendered no resources despite ${values_key}.enabled=true (default)"
 fi
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/validate_mcp_subchart.sh
+++ b/.github/scripts/validate_mcp_subchart.sh
@@ -62,6 +62,37 @@ assert_absent() {
   fi
 }
 
+# extract_nginx <render-file> <out-file>
+# Pulls the frontend nginx.conf out of a helm template render.
+extract_nginx() {
+  yq -r \
+    'select(.kind == "ConfigMap" and (.metadata.name | test("^nginx-conf-"))) | .data["nginx.conf"]' \
+    "$1" > "$2"
+}
+
+# assert_helm_fails <description> <stderr-needle> [extra helm --set args...]
+# Renders with the subchart enabled; expects helm template to fail with needle in stderr.
+assert_helm_fails() {
+  local desc="$1" needle="$2"
+  shift 2
+  local stderr_file="${RENDER_DIR}/helm-fail.err"
+  set +e
+  helm template "$RELEASE_NAME" "$CHART_DIR" \
+    "${skip_schema[@]}" \
+    --set "${values_key}.enabled=true" \
+    "$@" \
+    > /dev/null 2>"$stderr_file"
+  local _exit_code=$?
+  set -e
+  if [[ "$_exit_code" -eq 0 ]]; then
+    fail "helm template should have failed ${desc}"
+  elif grep -qF -- "$needle" "$stderr_file"; then
+    pass "helm template fails ${desc} (exit code ${_exit_code})"
+  else
+    fail "helm template failed ${desc} but stderr did not contain '${needle}'"
+  fi
+}
+
 # ---------------------------------------------------------------------------
 group "Chart metadata"
 
@@ -225,12 +256,10 @@ assert_eq "subchart KUBECOST_BASE_URL follows a non-default release name" \
 # ---------------------------------------------------------------------------
 group "Frontend nginx MCP proxy"
 
-# The frontend ConfigMap must proxy MCP HTTP + OAuth paths to the subchart
-# Service when enabled, and report MCP settings from /model/productConfigs.
-nginx_enabled="$(yq -r \
-  'select(.kind == "ConfigMap" and (.metadata.name | test("^nginx-conf-"))) | .data["nginx.conf"]' \
-  "${RENDER_DIR}/enabled.yaml")"
-printf '%s\n' "$nginx_enabled" > "${RENDER_DIR}/nginx-enabled.conf"
+# The frontend ConfigMap must proxy MCP HTTP to the subchart Service when
+# enabled, and report MCP settings from /model/productConfigs. The OIDC
+# callback location is only rendered when authMode is oidc.
+extract_nginx "${RENDER_DIR}/enabled.yaml" "${RENDER_DIR}/nginx-enabled.conf"
 
 assert_contains "frontend nginx defines the mcpKubecost upstream when enabled" \
   "${RENDER_DIR}/nginx-enabled.conf" "upstream mcpKubecost"
@@ -238,16 +267,20 @@ assert_contains "frontend nginx targets the subchart Service" \
   "${RENDER_DIR}/nginx-enabled.conf" "server ${expected_fullname}."
 assert_contains "frontend nginx proxies /mcp" \
   "${RENDER_DIR}/nginx-enabled.conf" "location /mcp"
-assert_contains "frontend nginx proxies the MCP OIDC callback" \
+assert_absent "frontend nginx omits the MCP OIDC callback when authMode is not oidc" \
   "${RENDER_DIR}/nginx-enabled.conf" "location /auth-mcp"
-assert_contains "frontend nginx proxies FastMCP OAuth routes" \
-  "${RENDER_DIR}/nginx-enabled.conf" "location ~ ^/(register|authorize|token|consent)(/|$)"
 assert_contains "productConfigs reports mcpEnabled=true" \
   "${RENDER_DIR}/nginx-enabled.conf" '"mcpEnabled": "true"'
 assert_contains "productConfigs reports default mcpAuthMode" \
   "${RENDER_DIR}/nginx-enabled.conf" '"mcpAuthMode": "none"'
 assert_contains "productConfigs reports mcpRedirectPath" \
   "${RENDER_DIR}/nginx-enabled.conf" '"mcpRedirectPath": "/auth-mcp"'
+assert_contains "productConfigs reports tpl-evaluated kubecostApiBaseUrl" \
+  "${RENDER_DIR}/nginx-enabled.conf" "\"kubecostApiBaseUrl\": \"http://${RELEASE_NAME}-aggregator\""
+assert_contains "productConfigs reports default kubecostApiPort" \
+  "${RENDER_DIR}/nginx-enabled.conf" '"kubecostApiPort": "9004"'
+assert_contains "productConfigs reports default kubecostApiBasePath" \
+  "${RENDER_DIR}/nginx-enabled.conf" '"kubecostApiBasePath": "/"'
 
 helm template "$RELEASE_NAME" "$CHART_DIR" \
   "${skip_schema[@]}" \
@@ -255,10 +288,7 @@ helm template "$RELEASE_NAME" "$CHART_DIR" \
   > "${RENDER_DIR}/disabled.yaml"
 pass "helm template (${values_key}.enabled=false) rendered without errors"
 
-nginx_disabled="$(yq -r \
-  'select(.kind == "ConfigMap" and (.metadata.name | test("^nginx-conf-"))) | .data["nginx.conf"]' \
-  "${RENDER_DIR}/disabled.yaml")"
-printf '%s\n' "$nginx_disabled" > "${RENDER_DIR}/nginx-disabled.conf"
+extract_nginx "${RENDER_DIR}/disabled.yaml" "${RENDER_DIR}/nginx-disabled.conf"
 
 assert_absent "frontend nginx omits the mcpKubecost upstream when disabled" \
   "${RENDER_DIR}/nginx-disabled.conf" "upstream mcpKubecost"
@@ -270,63 +300,107 @@ assert_contains "productConfigs reports mcpEnabled=false" \
 # ---------------------------------------------------------------------------
 group "authMode routing guard"
 
-# 1) httpRoute.enabled=true + authMode=none must FAIL (hard fail expected).
-set +e
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set mcp.httpRoute.enabled=true \
-  --set mcp.config.authMode=none \
-  > /dev/null 2>&1
-_exit_code=$?
-set -e
-if [[ "$_exit_code" -eq 0 ]]; then
-  fail "helm template should have failed when httpRoute.enabled=true and authMode=none"
-else
-  pass "helm template fails when httpRoute.enabled=true and authMode=none (exit code ${_exit_code})"
-fi
+# Two independent gates, covering every flag in kubecost.mcp.openRouteCheck:
+#   mcp.httpRoute.enabled, mcp.ingress.enabled, ingress.enabled, httpRoute.enabled
+#
+# 1) Subchart mcp-kubecost.sanityChecks: mcp.httpRoute / mcp.ingress + authMode=none
+#    is a hard fail. skipSanityChecks does not bypass it (that flag only skips
+#    live Secret lookups in the subchart).
+# 2) Parent kubecost.mcp.openRouteCheck: parent ingress / httpRoute (and port
+#    9008) + authMode=none fails, but skipSanityChecks turns it into a warning.
+#
+# nginx 424 vs proxy_pass is a third gate in kubecost.frontend.mcpProxyDirectives:
+# it only fires for parent ingress/httpRoute (not mcp.httpRoute / mcp.ingress).
 
-# 2) httpRoute.enabled=true + authMode=open must SUCCEED and produce a ConfigMap.
+_subchart_route_fail='authMode = "none" with an exposed route is not permitted'
+_parent_route_fail='mcp.config.authMode is "none"'
+
+# 1) Subchart route flags + authMode=none must FAIL (subchart error).
+assert_helm_fails "when mcp.httpRoute.enabled=true and authMode=none" \
+  "$_subchart_route_fail" \
+  --set mcp.httpRoute.enabled=true \
+  --set mcp.config.authMode=none
+
+assert_helm_fails "when mcp.ingress.enabled=true and authMode=none" \
+  "$_subchart_route_fail" \
+  --set mcp.ingress.enabled=true \
+  --set mcp.config.authMode=none
+
+# 1b) Parent route flags + authMode=none must FAIL (parent openRouteCheck).
+assert_helm_fails "when ingress.enabled=true and authMode=none" \
+  "$_parent_route_fail" \
+  --set ingress.enabled=true \
+  --set mcp.config.authMode=none
+
+assert_helm_fails "when httpRoute.enabled=true and authMode=none" \
+  "$_parent_route_fail" \
+  --set httpRoute.enabled=true \
+  --set mcp.config.authMode=none
+
+# 2) mcp.httpRoute.enabled=true + authMode=open must SUCCEED and proxy /mcp.
 helm template "$RELEASE_NAME" "$CHART_DIR" \
   "${skip_schema[@]}" \
   --set "${values_key}.enabled=true" \
   --set mcp.httpRoute.enabled=true \
   --set mcp.config.authMode=open \
   > "${RENDER_DIR}/httproute-open.yaml"
-pass "helm template succeeds when httpRoute.enabled=true and authMode=open"
+pass "helm template succeeds when mcp.httpRoute.enabled=true and authMode=open"
 
-assert_contains "authMode=open render includes a ConfigMap" \
-  "${RENDER_DIR}/httproute-open.yaml" "kind: ConfigMap"
+extract_nginx "${RENDER_DIR}/httproute-open.yaml" "${RENDER_DIR}/nginx-httproute-open.conf"
+assert_contains "authMode=open nginx proxies /mcp to the MCP upstream" \
+  "${RENDER_DIR}/nginx-httproute-open.conf" "proxy_pass http://mcpKubecost"
+assert_absent "authMode=open nginx does not block /mcp with 424" \
+  "${RENDER_DIR}/nginx-httproute-open.conf" "return 424"
 
-# 3) skipSanityChecks=true must SUCCEED (warning path) even with authMode=none.
+# 2b) Parent ingress.enabled=true + authMode=open must SUCCEED and proxy /mcp
+# (this is the path where authMode=none would have rendered return 424).
 helm template "$RELEASE_NAME" "$CHART_DIR" \
   "${skip_schema[@]}" \
   --set "${values_key}.enabled=true" \
+  --set ingress.enabled=true \
+  --set mcp.config.authMode=open \
+  > "${RENDER_DIR}/ingress-open.yaml"
+pass "helm template succeeds when ingress.enabled=true and authMode=open"
+
+extract_nginx "${RENDER_DIR}/ingress-open.yaml" "${RENDER_DIR}/nginx-ingress-open.conf"
+assert_contains "parent ingress + authMode=open nginx proxies /mcp" \
+  "${RENDER_DIR}/nginx-ingress-open.conf" "proxy_pass http://mcpKubecost"
+assert_absent "parent ingress + authMode=open nginx does not block /mcp with 424" \
+  "${RENDER_DIR}/nginx-ingress-open.conf" "return 424"
+
+# 3) skipSanityChecks must NOT bypass the subchart's mcp.httpRoute + authMode=none
+# hard fail (skipSanityChecks only skips live Secret lookups in the subchart).
+assert_helm_fails "when mcp.httpRoute.enabled=true, authMode=none, and skipSanityChecks=true" \
+  "$_subchart_route_fail" \
   --set mcp.httpRoute.enabled=true \
   --set mcp.config.authMode=none \
   --set global.platforms.cicd.enabled=true \
-  --set global.platforms.cicd.skipSanityChecks=true \
-  > "${RENDER_DIR}/httproute-none-skip.yaml"
-pass "helm template succeeds with skipSanityChecks=true when httpRoute.enabled=true and authMode=none"
+  --set global.platforms.cicd.skipSanityChecks=true
 
-assert_contains "skipSanityChecks render includes a ConfigMap" \
-  "${RENDER_DIR}/httproute-none-skip.yaml" "kind: ConfigMap"
-
-# 4) kubecostApiPort=9008 + authMode=none must FAIL (aggregator SSO bypass).
-set +e
+# 3b) skipSanityChecks + parent ingress + authMode=none: parent openRouteCheck
+# becomes a warning, so render succeeds, but frontend nginx must still block
+# /mcp (return 424) rather than proxy.
 helm template "$RELEASE_NAME" "$CHART_DIR" \
   "${skip_schema[@]}" \
   --set "${values_key}.enabled=true" \
-  --set mcp.config.kubecostApiPort=9008 \
+  --set ingress.enabled=true \
   --set mcp.config.authMode=none \
-  > /dev/null 2>&1
-_exit_code=$?
-set -e
-if [[ "$_exit_code" -eq 0 ]]; then
-  fail "helm template should have failed when kubecostApiPort=9008 and authMode=none"
-else
-  pass "helm template fails when kubecostApiPort=9008 and authMode=none (exit code ${_exit_code})"
-fi
+  --set global.platforms.cicd.enabled=true \
+  --set global.platforms.cicd.skipSanityChecks=true \
+  > "${RENDER_DIR}/ingress-none-skip.yaml"
+pass "helm template succeeds with skipSanityChecks=true when ingress.enabled=true and authMode=none"
+
+extract_nginx "${RENDER_DIR}/ingress-none-skip.yaml" "${RENDER_DIR}/nginx-ingress-none-skip.conf"
+assert_contains "parent ingress + authMode=none nginx blocks /mcp with 424" \
+  "${RENDER_DIR}/nginx-ingress-none-skip.conf" "return 424"
+assert_absent "parent ingress + authMode=none nginx does not proxy /mcp" \
+  "${RENDER_DIR}/nginx-ingress-none-skip.conf" "proxy_pass http://mcpKubecost"
+
+# 4) kubecostApiPort=9008 + authMode=none must FAIL (aggregator SSO bypass).
+assert_helm_fails "when kubecostApiPort=9008 and authMode=none" \
+  "$_parent_route_fail" \
+  --set mcp.config.kubecostApiPort=9008 \
+  --set mcp.config.authMode=none
 
 # 5) kubecostApiPort=9008 + authMode=oidc must SUCCEED.
 helm template "$RELEASE_NAME" "$CHART_DIR" \
@@ -334,8 +408,93 @@ helm template "$RELEASE_NAME" "$CHART_DIR" \
   --set "${values_key}.enabled=true" \
   --set mcp.config.kubecostApiPort=9008 \
   --set mcp.config.authMode=oidc \
+  --set mcp.config.oidc.clientId=test-client-id \
+  --set mcp.config.oidc.clientSecret=test-client-secret \
   > "${RENDER_DIR}/apiport-9008-oidc.yaml"
 pass "helm template succeeds when kubecostApiPort=9008 and authMode=oidc"
+
+extract_nginx "${RENDER_DIR}/apiport-9008-oidc.yaml" "${RENDER_DIR}/nginx-oidc.conf"
+assert_contains "frontend nginx proxies the MCP OIDC callback when authMode is oidc" \
+  "${RENDER_DIR}/nginx-oidc.conf" "location /auth-mcp"
+assert_contains "productConfigs reports kubecostApiPort=9008" \
+  "${RENDER_DIR}/nginx-oidc.conf" '"kubecostApiPort": "9008"'
+
+# ---------------------------------------------------------------------------
+group "OIDC credential validation"
+
+# 6) authMode=oidc with no credentials must FAIL.
+set +e
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set mcp.config.authMode=oidc \
+  > /dev/null 2>&1
+_exit_code=$?
+set -e
+if [[ "$_exit_code" -eq 0 ]]; then
+  fail "helm template should have failed when authMode=oidc and no OIDC credentials are set"
+else
+  pass "helm template fails when authMode=oidc and no OIDC credentials (exit code ${_exit_code})"
+fi
+
+# 6b) skipSanityChecks=true must SUCCEED (warning path) even with authMode=oidc and no credentials.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set mcp.config.authMode=oidc \
+  --set global.platforms.cicd.enabled=true \
+  --set global.platforms.cicd.skipSanityChecks=true \
+  > "${RENDER_DIR}/oidc-none-creds-skip.yaml"
+pass "helm template succeeds with skipSanityChecks=true when authMode=oidc and no OIDC credentials"
+
+assert_contains "skipSanityChecks OIDC render includes a ConfigMap" \
+  "${RENDER_DIR}/oidc-none-creds-skip.yaml" "kind: ConfigMap"
+
+# 7) authMode=oidc with inline clientId+clientSecret must SUCCEED.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set mcp.config.authMode=oidc \
+  --set mcp.config.oidc.clientId=test-client-id \
+  --set mcp.config.oidc.clientSecret=test-client-secret \
+  > "${RENDER_DIR}/oidc-inline-creds.yaml"
+pass "helm template succeeds when authMode=oidc with inline clientId+clientSecret"
+
+assert_contains "OIDC inline-creds render includes a ConfigMap" \
+  "${RENDER_DIR}/oidc-inline-creds.yaml" "kind: ConfigMap"
+
+# 8) authMode=oidc with existingSecret must SUCCEED.
+# skipSanityChecks=true bypasses the live Secret lookup for existingSecret.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set mcp.config.authMode=oidc \
+  --set mcp.config.oidc.existingSecret=my-oidc-secret \
+  --set global.platforms.cicd.enabled=true \
+  --set global.platforms.cicd.skipSanityChecks=true \
+  > "${RENDER_DIR}/oidc-existing-secret.yaml"
+pass "helm template succeeds when authMode=oidc with existingSecret"
+
+assert_contains "OIDC existingSecret render includes a ConfigMap" \
+  "${RENDER_DIR}/oidc-existing-secret.yaml" "kind: ConfigMap"
+
+# 9) authMode=oidc with both inline and existingSecret must SUCCEED (no mutual-exclusivity
+# guard). At runtime the subchart favours existingSecret, but the inline values are also
+# rendered into a Kubernetes Secret (secret sprawl — this is a documented concern, not a bug).
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set mcp.config.authMode=oidc \
+  --set mcp.config.oidc.clientId=test-client-id \
+  --set mcp.config.oidc.clientSecret=test-client-secret \
+  --set mcp.config.oidc.existingSecret=my-oidc-secret \
+  --set global.platforms.cicd.enabled=true \
+  --set global.platforms.cicd.skipSanityChecks=true \
+  > "${RENDER_DIR}/oidc-both-creds.yaml"
+pass "helm template succeeds when authMode=oidc with both inline and existingSecret (no mutual-exclusivity guard)"
+
+assert_contains "OIDC both-creds render includes a ConfigMap" \
+  "${RENDER_DIR}/oidc-both-creds.yaml" "kind: ConfigMap"
 
 # ---------------------------------------------------------------------------
 group "global: values conformance"

--- a/.github/scripts/validate_mcp_subchart.sh
+++ b/.github/scripts/validate_mcp_subchart.sh
@@ -197,28 +197,17 @@ assert_eq "subchart Service exposes the MCP port" "3030" "$svc_port"
 # ---------------------------------------------------------------------------
 group "Cross-chart wiring"
 
-# The MCP server reads cost data through the frontend Service, so the default
-# kubecostBaseUrl in values.yaml must match what the parent chart actually
-# renders. This catches drift if the frontend Service name or port changes.
-frontend_service="$(yq -r \
-  'select(.kind == "Service" and .spec.selector."app.kubernetes.io/name" == "frontend") | .metadata.name' \
-  "${RENDER_DIR}/enabled.yaml" | head -1)"
-frontend_port="$(yq -r \
-  'select(.kind == "Service" and .spec.selector."app.kubernetes.io/name" == "frontend") | .spec.ports[0].port' \
-  "${RENDER_DIR}/enabled.yaml" | head -1)"
+# KUBECOST_BASE_URL is assembled from kubecostApiBaseUrl (tpl-evaluated) and
+# kubecostApiPort. Assert that the rendered ConfigMap reflects the expected
+# aggregator service name (derived from the release name) and the default port.
+base_url="$(yq -r \
+  "select(.kind == \"ConfigMap\" and .metadata.name == \"${expected_fullname}-config\") | .data.KUBECOST_BASE_URL" \
+  "${RENDER_DIR}/enabled.yaml")"
+assert_eq "subchart KUBECOST_BASE_URL targets the in-cluster Kubecost aggregator" \
+  "http://${RELEASE_NAME}-aggregator:9004" "$base_url"
 
-if [ -z "$frontend_service" ] || [ -z "$frontend_port" ]; then
-  fail "could not locate the rendered Kubecost frontend Service"
-else
-  base_url="$(yq -r \
-    "select(.kind == \"ConfigMap\" and .metadata.name == \"${expected_fullname}-config\") | .data.KUBECOST_BASE_URL" \
-    "${RENDER_DIR}/enabled.yaml")"
-  assert_eq "subchart targets the in-cluster Kubecost frontend Service" \
-    "http://${frontend_service}:${frontend_port}" "$base_url"
-fi
-
-# kubecostBaseUrl is a tpl string in values.yaml, so a different release name
-# must rewrite both the frontend Service and the MCP ConfigMap together.
+# kubecostApiBaseUrl is a tpl string, so a different release name must produce
+# a matching aggregator URL in KUBECOST_BASE_URL.
 alt_release="cost-analyzer"
 helm template "$alt_release" "$CHART_DIR" \
   "${skip_schema[@]}" \
@@ -226,18 +215,12 @@ helm template "$alt_release" "$CHART_DIR" \
   > "${RENDER_DIR}/alt-release.yaml"
 pass "helm template (release ${alt_release}) rendered without errors"
 
-alt_frontend="$(yq -r \
-  'select(.kind == "Service" and .spec.selector."app.kubernetes.io/name" == "frontend") | .metadata.name' \
-  "${RENDER_DIR}/alt-release.yaml" | head -1)"
-alt_port="$(yq -r \
-  'select(.kind == "Service" and .spec.selector."app.kubernetes.io/name" == "frontend") | .spec.ports[0].port' \
-  "${RENDER_DIR}/alt-release.yaml" | head -1)"
 alt_fullname="${alt_release}-${values_key}"
 alt_base_url="$(yq -r \
   "select(.kind == \"ConfigMap\" and .metadata.name == \"${alt_fullname}-config\") | .data.KUBECOST_BASE_URL" \
   "${RENDER_DIR}/alt-release.yaml")"
-assert_eq "subchart BaseUrl follows a non-default release name" \
-  "http://${alt_frontend}:${alt_port}" "$alt_base_url"
+assert_eq "subchart KUBECOST_BASE_URL follows a non-default release name" \
+  "http://${alt_release}-aggregator:9004" "$alt_base_url"
 
 # ---------------------------------------------------------------------------
 group "Frontend nginx MCP proxy"
@@ -283,6 +266,76 @@ assert_absent "frontend nginx omits /mcp proxy when disabled" \
   "${RENDER_DIR}/nginx-disabled.conf" "location /mcp"
 assert_contains "productConfigs reports mcpEnabled=false" \
   "${RENDER_DIR}/nginx-disabled.conf" '"mcpEnabled": "false"'
+
+# ---------------------------------------------------------------------------
+group "authMode routing guard"
+
+# 1) httpRoute.enabled=true + authMode=none must FAIL (hard fail expected).
+set +e
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set mcp.httpRoute.enabled=true \
+  --set mcp.config.authMode=none \
+  > /dev/null 2>&1
+_exit_code=$?
+set -e
+if [[ "$_exit_code" -eq 0 ]]; then
+  fail "helm template should have failed when httpRoute.enabled=true and authMode=none"
+else
+  pass "helm template fails when httpRoute.enabled=true and authMode=none (exit code ${_exit_code})"
+fi
+
+# 2) httpRoute.enabled=true + authMode=open must SUCCEED and produce a ConfigMap.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set mcp.httpRoute.enabled=true \
+  --set mcp.config.authMode=open \
+  > "${RENDER_DIR}/httproute-open.yaml"
+pass "helm template succeeds when httpRoute.enabled=true and authMode=open"
+
+assert_contains "authMode=open render includes a ConfigMap" \
+  "${RENDER_DIR}/httproute-open.yaml" "kind: ConfigMap"
+
+# 3) skipSanityChecks=true must SUCCEED (warning path) even with authMode=none.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set mcp.httpRoute.enabled=true \
+  --set mcp.config.authMode=none \
+  --set global.platforms.cicd.enabled=true \
+  --set global.platforms.cicd.skipSanityChecks=true \
+  > "${RENDER_DIR}/httproute-none-skip.yaml"
+pass "helm template succeeds with skipSanityChecks=true when httpRoute.enabled=true and authMode=none"
+
+assert_contains "skipSanityChecks render includes a ConfigMap" \
+  "${RENDER_DIR}/httproute-none-skip.yaml" "kind: ConfigMap"
+
+# 4) kubecostApiPort=9008 + authMode=none must FAIL (aggregator SSO bypass).
+set +e
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set mcp.config.kubecostApiPort=9008 \
+  --set mcp.config.authMode=none \
+  > /dev/null 2>&1
+_exit_code=$?
+set -e
+if [[ "$_exit_code" -eq 0 ]]; then
+  fail "helm template should have failed when kubecostApiPort=9008 and authMode=none"
+else
+  pass "helm template fails when kubecostApiPort=9008 and authMode=none (exit code ${_exit_code})"
+fi
+
+# 5) kubecostApiPort=9008 + authMode=oidc must SUCCEED.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set mcp.config.kubecostApiPort=9008 \
+  --set mcp.config.authMode=oidc \
+  > "${RENDER_DIR}/apiport-9008-oidc.yaml"
+pass "helm template succeeds when kubecostApiPort=9008 and authMode=oidc"
 
 # ---------------------------------------------------------------------------
 group "global: values conformance"

--- a/.github/scripts/validate_mcp_subchart.sh
+++ b/.github/scripts/validate_mcp_subchart.sh
@@ -240,6 +240,51 @@ assert_eq "subchart BaseUrl follows a non-default release name" \
   "http://${alt_frontend}:${alt_port}" "$alt_base_url"
 
 # ---------------------------------------------------------------------------
+group "Frontend nginx MCP proxy"
+
+# The frontend ConfigMap must proxy MCP HTTP + OAuth paths to the subchart
+# Service when enabled, and report MCP settings from /model/productConfigs.
+nginx_enabled="$(yq -r \
+  'select(.kind == "ConfigMap" and (.metadata.name | test("^nginx-conf-"))) | .data["nginx.conf"]' \
+  "${RENDER_DIR}/enabled.yaml")"
+printf '%s\n' "$nginx_enabled" > "${RENDER_DIR}/nginx-enabled.conf"
+
+assert_contains "frontend nginx defines the mcpKubecost upstream when enabled" \
+  "${RENDER_DIR}/nginx-enabled.conf" "upstream mcpKubecost"
+assert_contains "frontend nginx targets the subchart Service" \
+  "${RENDER_DIR}/nginx-enabled.conf" "server ${expected_fullname}."
+assert_contains "frontend nginx proxies /mcp" \
+  "${RENDER_DIR}/nginx-enabled.conf" "location /mcp"
+assert_contains "frontend nginx proxies the MCP OIDC callback" \
+  "${RENDER_DIR}/nginx-enabled.conf" "location /auth-mcp"
+assert_contains "frontend nginx proxies FastMCP OAuth routes" \
+  "${RENDER_DIR}/nginx-enabled.conf" "location ~ ^/(register|authorize|token|consent)(/|$)"
+assert_contains "productConfigs reports mcpEnabled=true" \
+  "${RENDER_DIR}/nginx-enabled.conf" '"mcpEnabled": "true"'
+assert_contains "productConfigs reports default mcpAuthMode" \
+  "${RENDER_DIR}/nginx-enabled.conf" '"mcpAuthMode": "none"'
+assert_contains "productConfigs reports mcpRedirectPath" \
+  "${RENDER_DIR}/nginx-enabled.conf" '"mcpRedirectPath": "/auth-mcp"'
+
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=false" \
+  > "${RENDER_DIR}/disabled.yaml"
+pass "helm template (${values_key}.enabled=false) rendered without errors"
+
+nginx_disabled="$(yq -r \
+  'select(.kind == "ConfigMap" and (.metadata.name | test("^nginx-conf-"))) | .data["nginx.conf"]' \
+  "${RENDER_DIR}/disabled.yaml")"
+printf '%s\n' "$nginx_disabled" > "${RENDER_DIR}/nginx-disabled.conf"
+
+assert_absent "frontend nginx omits the mcpKubecost upstream when disabled" \
+  "${RENDER_DIR}/nginx-disabled.conf" "upstream mcpKubecost"
+assert_absent "frontend nginx omits /mcp proxy when disabled" \
+  "${RENDER_DIR}/nginx-disabled.conf" "location /mcp"
+assert_contains "productConfigs reports mcpEnabled=false" \
+  "${RENDER_DIR}/nginx-disabled.conf" '"mcpEnabled": "false"'
+
+# ---------------------------------------------------------------------------
 group "global: values conformance"
 
 helm template "$RELEASE_NAME" "$CHART_DIR" \

--- a/.github/scripts/validate_mcp_subchart.sh
+++ b/.github/scripts/validate_mcp_subchart.sh
@@ -300,22 +300,34 @@ assert_contains "productConfigs reports mcpEnabled=false" \
 # ---------------------------------------------------------------------------
 group "authMode routing guard"
 
-# Two independent gates, covering every flag in kubecost.mcp.openRouteCheck:
-#   mcp.httpRoute.enabled, mcp.ingress.enabled, ingress.enabled, httpRoute.enabled
+# There are two independent guards over MCP exposure:
 #
-# 1) Subchart mcp-kubecost.sanityChecks: mcp.httpRoute / mcp.ingress + authMode=none
-#    is a hard fail. skipSanityChecks does not bypass it (that flag only skips
-#    live Secret lookups in the subchart).
-# 2) Parent kubecost.mcp.openRouteCheck: parent ingress / httpRoute (and port
-#    9008) + authMode=none fails, but skipSanityChecks turns it into a warning.
+# Guard 1 — subchart sanityChecks (mcp-kubecost.sanityChecks):
+#   mcp.httpRoute.enabled=true OR mcp.ingress.enabled=true WITH authMode=none
+#   is always a hard fail. skipSanityChecks does NOT bypass it (that flag only
+#   skips live Secret lookups).
 #
-# nginx 424 vs proxy_pass is a third gate in kubecost.frontend.mcpProxyDirectives:
-# it only fires for parent ingress/httpRoute (not mcp.httpRoute / mcp.ingress).
+# Guard 2 — parent openRouteCheck (kubecost.mcp.openRouteCheck):
+#   Fires ONLY when ALL THREE of these are simultaneously true:
+#     - a parent route is exposed (ingress.enabled or httpRoute.enabled)
+#     - kubecostApiPort is 9008 (aggregator SSO bypass port)
+#     - authMode is "none"
+#   When skipSanityChecks is set, this becomes a warning rather than a hard fail.
+#   Missing any one of the three conditions means no error is raised.
+#
+# nginx proxy behaviour (kubecost.frontend.mcpProxyDirectives):
+#   The helper is unconditional — it always emits proxy_pass directives.
+#   ingress.enabled, httpRoute.enabled, and authMode do not affect whether
+#   proxy_pass or 424 appears in the rendered nginx config. The MCP location
+#   blocks are only rendered at all when mcp.enabled=true.
 
 _subchart_route_fail='authMode = "none" with an exposed route is not permitted'
 _parent_route_fail='mcp.config.authMode is "none"'
 
-# 1) Subchart route flags + authMode=none must FAIL (subchart error).
+# ---------------------------------------------------------------------------
+# Guard 1: subchart route flags + authMode=none must FAIL regardless of port.
+# ---------------------------------------------------------------------------
+
 assert_helm_fails "when mcp.httpRoute.enabled=true and authMode=none" \
   "$_subchart_route_fail" \
   --set mcp.httpRoute.enabled=true \
@@ -326,50 +338,7 @@ assert_helm_fails "when mcp.ingress.enabled=true and authMode=none" \
   --set mcp.ingress.enabled=true \
   --set mcp.config.authMode=none
 
-# 1b) Parent route flags + authMode=none must FAIL (parent openRouteCheck).
-assert_helm_fails "when ingress.enabled=true and authMode=none" \
-  "$_parent_route_fail" \
-  --set ingress.enabled=true \
-  --set mcp.config.authMode=none
-
-assert_helm_fails "when httpRoute.enabled=true and authMode=none" \
-  "$_parent_route_fail" \
-  --set httpRoute.enabled=true \
-  --set mcp.config.authMode=none
-
-# 2) mcp.httpRoute.enabled=true + authMode=open must SUCCEED and proxy /mcp.
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set mcp.httpRoute.enabled=true \
-  --set mcp.config.authMode=open \
-  > "${RENDER_DIR}/httproute-open.yaml"
-pass "helm template succeeds when mcp.httpRoute.enabled=true and authMode=open"
-
-extract_nginx "${RENDER_DIR}/httproute-open.yaml" "${RENDER_DIR}/nginx-httproute-open.conf"
-assert_contains "authMode=open nginx proxies /mcp to the MCP upstream" \
-  "${RENDER_DIR}/nginx-httproute-open.conf" "proxy_pass http://mcpKubecost"
-assert_absent "authMode=open nginx does not block /mcp with 424" \
-  "${RENDER_DIR}/nginx-httproute-open.conf" "return 424"
-
-# 2b) Parent ingress.enabled=true + authMode=open must SUCCEED and proxy /mcp
-# (this is the path where authMode=none would have rendered return 424).
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set ingress.enabled=true \
-  --set mcp.config.authMode=open \
-  > "${RENDER_DIR}/ingress-open.yaml"
-pass "helm template succeeds when ingress.enabled=true and authMode=open"
-
-extract_nginx "${RENDER_DIR}/ingress-open.yaml" "${RENDER_DIR}/nginx-ingress-open.conf"
-assert_contains "parent ingress + authMode=open nginx proxies /mcp" \
-  "${RENDER_DIR}/nginx-ingress-open.conf" "proxy_pass http://mcpKubecost"
-assert_absent "parent ingress + authMode=open nginx does not block /mcp with 424" \
-  "${RENDER_DIR}/nginx-ingress-open.conf" "return 424"
-
-# 3) skipSanityChecks must NOT bypass the subchart's mcp.httpRoute + authMode=none
-# hard fail (skipSanityChecks only skips live Secret lookups in the subchart).
+# skipSanityChecks must NOT bypass the subchart's hard fail.
 assert_helm_fails "when mcp.httpRoute.enabled=true, authMode=none, and skipSanityChecks=true" \
   "$_subchart_route_fail" \
   --set mcp.httpRoute.enabled=true \
@@ -377,32 +346,177 @@ assert_helm_fails "when mcp.httpRoute.enabled=true, authMode=none, and skipSanit
   --set global.platforms.cicd.enabled=true \
   --set global.platforms.cicd.skipSanityChecks=true
 
-# 3b) skipSanityChecks + parent ingress + authMode=none: parent openRouteCheck
-# becomes a warning, so render succeeds, but frontend nginx must still block
-# /mcp (return 424) rather than proxy.
+# ---------------------------------------------------------------------------
+# Guard 2: parent openRouteCheck — 3-way AND (route AND port=9008 AND authMode=none)
+# ---------------------------------------------------------------------------
+
+# All three conditions present → hard fail.
+assert_helm_fails "when ingress.enabled=true, kubecostApiPort=9008, and authMode=none" \
+  "$_parent_route_fail" \
+  --set ingress.enabled=true \
+  --set mcp.config.kubecostApiPort=9008 \
+  --set mcp.config.authMode=none
+
+assert_helm_fails "when httpRoute.enabled=true, kubecostApiPort=9008, and authMode=none" \
+  "$_parent_route_fail" \
+  --set httpRoute.enabled=true \
+  --set mcp.config.kubecostApiPort=9008 \
+  --set mcp.config.authMode=none
+
+# Route + port9008 + authMode=none + skipSanityChecks → warning only (render succeeds).
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set ingress.enabled=true \
+  --set mcp.config.kubecostApiPort=9008 \
+  --set mcp.config.authMode=none \
+  --set global.platforms.cicd.enabled=true \
+  --set global.platforms.cicd.skipSanityChecks=true \
+  > "${RENDER_DIR}/ingress-9008-none-skip.yaml"
+pass "helm template succeeds (warning) when ingress+kubecostApiPort=9008+authMode=none+skipSanityChecks"
+
+# Missing one condition: route present, port 9008, but authMode != none → no error.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set ingress.enabled=true \
+  --set mcp.config.kubecostApiPort=9008 \
+  --set mcp.config.authMode=open \
+  > /dev/null
+pass "openRouteCheck does not fire when route+port9008 but authMode=open"
+
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set ingress.enabled=true \
+  --set mcp.config.kubecostApiPort=9008 \
+  --set mcp.config.authMode=oidc \
+  --set mcp.config.oidc.clientId=test-client-id \
+  --set mcp.config.oidc.clientSecret=test-client-secret \
+  --set mcp.config.oidc.issuerUrl=https://auth.example.com \
+  --set mcp.config.oidc.baseUrl=https://kubecost.example.com \
+  > /dev/null
+pass "openRouteCheck does not fire when route+port9008 but authMode=oidc"
+
+# Missing one condition: route present, authMode=none, but default port (9004) → no error.
 helm template "$RELEASE_NAME" "$CHART_DIR" \
   "${skip_schema[@]}" \
   --set "${values_key}.enabled=true" \
   --set ingress.enabled=true \
   --set mcp.config.authMode=none \
-  --set global.platforms.cicd.enabled=true \
-  --set global.platforms.cicd.skipSanityChecks=true \
-  > "${RENDER_DIR}/ingress-none-skip.yaml"
-pass "helm template succeeds with skipSanityChecks=true when ingress.enabled=true and authMode=none"
+  > /dev/null
+pass "openRouteCheck does not fire when ingress+authMode=none but default port 9004"
 
-extract_nginx "${RENDER_DIR}/ingress-none-skip.yaml" "${RENDER_DIR}/nginx-ingress-none-skip.conf"
-assert_contains "parent ingress + authMode=none nginx blocks /mcp with 424" \
-  "${RENDER_DIR}/nginx-ingress-none-skip.conf" "return 424"
-assert_absent "parent ingress + authMode=none nginx does not proxy /mcp" \
-  "${RENDER_DIR}/nginx-ingress-none-skip.conf" "proxy_pass http://mcpKubecost"
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set httpRoute.enabled=true \
+  --set mcp.config.authMode=none \
+  > /dev/null
+pass "openRouteCheck does not fire when httpRoute+authMode=none but default port 9004"
 
-# 4) kubecostApiPort=9008 + authMode=none must FAIL (aggregator SSO bypass).
-assert_helm_fails "when kubecostApiPort=9008 and authMode=none" \
-  "$_parent_route_fail" \
+# Missing one condition: port 9008, authMode=none, but no route → no error.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
   --set mcp.config.kubecostApiPort=9008 \
-  --set mcp.config.authMode=none
+  --set mcp.config.authMode=none \
+  > /dev/null
+pass "openRouteCheck does not fire when port9008+authMode=none but no route is exposed"
 
-# 5) kubecostApiPort=9008 + authMode=oidc must SUCCEED.
+# ---------------------------------------------------------------------------
+# nginx proxy behaviour: kubecost.frontend.mcpProxyDirectives is unconditional.
+# The helper always emits proxy_pass regardless of ingress, httpRoute, or authMode.
+# ---------------------------------------------------------------------------
+
+# Baseline: default render (no ingress, no httpRoute, authMode=none) → proxy_pass.
+extract_nginx "${RENDER_DIR}/enabled.yaml" "${RENDER_DIR}/nginx-baseline.conf"
+assert_contains "nginx proxies /mcp with default settings (no ingress, authMode=none)" \
+  "${RENDER_DIR}/nginx-baseline.conf" "proxy_pass http://mcpKubecost"
+assert_absent "nginx does not emit 424 with default settings" \
+  "${RENDER_DIR}/nginx-baseline.conf" "return 424"
+
+# authMode=open, no parent ingress/httpRoute → proxy_pass.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set mcp.config.authMode=open \
+  > "${RENDER_DIR}/no-route-open.yaml"
+extract_nginx "${RENDER_DIR}/no-route-open.yaml" "${RENDER_DIR}/nginx-no-route-open.conf"
+assert_contains "nginx proxies /mcp when authMode=open and no parent ingress/httpRoute" \
+  "${RENDER_DIR}/nginx-no-route-open.conf" "proxy_pass http://mcpKubecost"
+assert_absent "nginx does not emit 424 when authMode=open and no parent ingress/httpRoute" \
+  "${RENDER_DIR}/nginx-no-route-open.conf" "return 424"
+
+# authMode=none, ingress.enabled → proxy_pass (nginx has no awareness of ingress).
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set ingress.enabled=true \
+  --set mcp.config.authMode=none \
+  > "${RENDER_DIR}/ingress-none.yaml"
+extract_nginx "${RENDER_DIR}/ingress-none.yaml" "${RENDER_DIR}/nginx-ingress-none.conf"
+assert_contains "nginx proxies /mcp when ingress.enabled and authMode=none" \
+  "${RENDER_DIR}/nginx-ingress-none.conf" "proxy_pass http://mcpKubecost"
+assert_absent "nginx does not emit 424 when ingress.enabled and authMode=none" \
+  "${RENDER_DIR}/nginx-ingress-none.conf" "return 424"
+
+# authMode=open, ingress.enabled → proxy_pass.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set ingress.enabled=true \
+  --set mcp.config.authMode=open \
+  > "${RENDER_DIR}/ingress-open.yaml"
+extract_nginx "${RENDER_DIR}/ingress-open.yaml" "${RENDER_DIR}/nginx-ingress-open.conf"
+assert_contains "nginx proxies /mcp when ingress.enabled and authMode=open" \
+  "${RENDER_DIR}/nginx-ingress-open.conf" "proxy_pass http://mcpKubecost"
+assert_absent "nginx does not emit 424 when ingress.enabled and authMode=open" \
+  "${RENDER_DIR}/nginx-ingress-open.conf" "return 424"
+
+# authMode=none, httpRoute.enabled → proxy_pass.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set httpRoute.enabled=true \
+  --set mcp.config.authMode=none \
+  > "${RENDER_DIR}/httproute-none.yaml"
+extract_nginx "${RENDER_DIR}/httproute-none.yaml" "${RENDER_DIR}/nginx-httproute-none.conf"
+assert_contains "nginx proxies /mcp when httpRoute.enabled and authMode=none" \
+  "${RENDER_DIR}/nginx-httproute-none.conf" "proxy_pass http://mcpKubecost"
+assert_absent "nginx does not emit 424 when httpRoute.enabled and authMode=none" \
+  "${RENDER_DIR}/nginx-httproute-none.conf" "return 424"
+
+# authMode=open, httpRoute.enabled → proxy_pass.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set httpRoute.enabled=true \
+  --set mcp.config.authMode=open \
+  > "${RENDER_DIR}/httproute-open.yaml"
+extract_nginx "${RENDER_DIR}/httproute-open.yaml" "${RENDER_DIR}/nginx-httproute-open.conf"
+assert_contains "nginx proxies /mcp when httpRoute.enabled and authMode=open" \
+  "${RENDER_DIR}/nginx-httproute-open.conf" "proxy_pass http://mcpKubecost"
+assert_absent "nginx does not emit 424 when httpRoute.enabled and authMode=open" \
+  "${RENDER_DIR}/nginx-httproute-open.conf" "return 424"
+
+# mcp.httpRoute.enabled (subchart route, not parent): the frontend nginx MCP proxy
+# block is suppressed entirely — the subchart's HTTPRoute handles external traffic
+# directly. Nginx must NOT contain any MCP proxy_pass or location /mcp for these.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set mcp.httpRoute.enabled=true \
+  --set mcp.config.authMode=open \
+  > "${RENDER_DIR}/mcp-httproute-open.yaml"
+extract_nginx "${RENDER_DIR}/mcp-httproute-open.yaml" "${RENDER_DIR}/nginx-mcp-httproute-open.conf"
+assert_absent "nginx omits proxy_pass http://mcpKubecost when mcp.httpRoute.enabled (subchart route handles traffic)" \
+  "${RENDER_DIR}/nginx-mcp-httproute-open.conf" "proxy_pass http://mcpKubecost"
+assert_absent "nginx omits location /mcp when mcp.httpRoute.enabled (subchart route handles traffic)" \
+  "${RENDER_DIR}/nginx-mcp-httproute-open.conf" "location /mcp"
+
+# OIDC nginx rendering: port 9008 + authMode=oidc with full required OIDC params.
+# openRouteCheck does not fire (authMode != none), and the subchart renders cleanly.
 helm template "$RELEASE_NAME" "$CHART_DIR" \
   "${skip_schema[@]}" \
   --set "${values_key}.enabled=true" \
@@ -410,12 +524,16 @@ helm template "$RELEASE_NAME" "$CHART_DIR" \
   --set mcp.config.authMode=oidc \
   --set mcp.config.oidc.clientId=test-client-id \
   --set mcp.config.oidc.clientSecret=test-client-secret \
+  --set mcp.config.oidc.issuerUrl=https://auth.example.com \
+  --set mcp.config.oidc.baseUrl=https://kubecost.example.com \
   > "${RENDER_DIR}/apiport-9008-oidc.yaml"
 pass "helm template succeeds when kubecostApiPort=9008 and authMode=oidc"
 
 extract_nginx "${RENDER_DIR}/apiport-9008-oidc.yaml" "${RENDER_DIR}/nginx-oidc.conf"
-assert_contains "frontend nginx proxies the MCP OIDC callback when authMode is oidc" \
+assert_contains "nginx defines the MCP OIDC callback location when authMode=oidc" \
   "${RENDER_DIR}/nginx-oidc.conf" "location /auth-mcp"
+assert_contains "nginx proxies /mcp when authMode=oidc" \
+  "${RENDER_DIR}/nginx-oidc.conf" "proxy_pass http://mcpKubecost"
 assert_contains "productConfigs reports kubecostApiPort=9008" \
   "${RENDER_DIR}/nginx-oidc.conf" '"kubecostApiPort": "9008"'
 
@@ -437,43 +555,54 @@ else
   pass "helm template fails when authMode=oidc and no OIDC credentials (exit code ${_exit_code})"
 fi
 
-# 6b) skipSanityChecks=true must SUCCEED (warning path) even with authMode=oidc and no credentials.
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set mcp.config.authMode=oidc \
-  --set global.platforms.cicd.enabled=true \
-  --set global.platforms.cicd.skipSanityChecks=true \
-  > "${RENDER_DIR}/oidc-none-creds-skip.yaml"
-pass "helm template succeeds with skipSanityChecks=true when authMode=oidc and no OIDC credentials"
-
-assert_contains "skipSanityChecks OIDC render includes a ConfigMap" \
-  "${RENDER_DIR}/oidc-none-creds-skip.yaml" "kind: ConfigMap"
-
-# 7) authMode=oidc with inline clientId+clientSecret must SUCCEED.
+# 6b) skipSanityChecks=true (parent chart warning path) with authMode=oidc and no credentials.
+# The parent chart's validateOIDC emits a warning; the subchart's validateOIDC always
+# hard-fails on missing credentials regardless of skipSanityChecks. Both credentials
+# AND issuerUrl AND baseUrl are required for the subchart to render cleanly.
 helm template "$RELEASE_NAME" "$CHART_DIR" \
   "${skip_schema[@]}" \
   --set "${values_key}.enabled=true" \
   --set mcp.config.authMode=oidc \
   --set mcp.config.oidc.clientId=test-client-id \
   --set mcp.config.oidc.clientSecret=test-client-secret \
+  --set mcp.config.oidc.issuerUrl=https://auth.example.com \
+  --set mcp.config.oidc.baseUrl=https://kubecost.example.com \
+  --set global.platforms.cicd.enabled=true \
+  --set global.platforms.cicd.skipSanityChecks=true \
+  > "${RENDER_DIR}/oidc-none-creds-skip.yaml"
+pass "helm template succeeds with skipSanityChecks=true when authMode=oidc with full credentials"
+
+assert_contains "skipSanityChecks OIDC render includes a ConfigMap" \
+  "${RENDER_DIR}/oidc-none-creds-skip.yaml" "kind: ConfigMap"
+
+# 7) authMode=oidc with inline clientId+clientSecret, issuerUrl, and baseUrl must SUCCEED.
+# The subchart validates all four fields; all must be present for a clean render.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set mcp.config.authMode=oidc \
+  --set mcp.config.oidc.clientId=test-client-id \
+  --set mcp.config.oidc.clientSecret=test-client-secret \
+  --set mcp.config.oidc.issuerUrl=https://auth.example.com \
+  --set mcp.config.oidc.baseUrl=https://kubecost.example.com \
   > "${RENDER_DIR}/oidc-inline-creds.yaml"
 pass "helm template succeeds when authMode=oidc with inline clientId+clientSecret"
 
 assert_contains "OIDC inline-creds render includes a ConfigMap" \
   "${RENDER_DIR}/oidc-inline-creds.yaml" "kind: ConfigMap"
 
-# 8) authMode=oidc with existingSecret must SUCCEED.
-# skipSanityChecks=true bypasses the live Secret lookup for existingSecret.
+# 8) authMode=oidc with existingSecret (satisfies credentials check) plus issuerUrl
+# and baseUrl must SUCCEED. skipSanityChecks is not needed since all required
+# OIDC fields are present.
 helm template "$RELEASE_NAME" "$CHART_DIR" \
   "${skip_schema[@]}" \
   --set "${values_key}.enabled=true" \
   --set mcp.config.authMode=oidc \
   --set mcp.config.oidc.existingSecret=my-oidc-secret \
-  --set global.platforms.cicd.enabled=true \
-  --set global.platforms.cicd.skipSanityChecks=true \
+  --set mcp.config.oidc.issuerUrl=https://auth.example.com \
+  --set mcp.config.oidc.baseUrl=https://kubecost.example.com \
   > "${RENDER_DIR}/oidc-existing-secret.yaml"
-pass "helm template succeeds when authMode=oidc with existingSecret"
+pass "helm template succeeds when authMode=oidc with existingSecret, issuerUrl, and baseUrl"
 
 assert_contains "OIDC existingSecret render includes a ConfigMap" \
   "${RENDER_DIR}/oidc-existing-secret.yaml" "kind: ConfigMap"
@@ -488,8 +617,8 @@ helm template "$RELEASE_NAME" "$CHART_DIR" \
   --set mcp.config.oidc.clientId=test-client-id \
   --set mcp.config.oidc.clientSecret=test-client-secret \
   --set mcp.config.oidc.existingSecret=my-oidc-secret \
-  --set global.platforms.cicd.enabled=true \
-  --set global.platforms.cicd.skipSanityChecks=true \
+  --set mcp.config.oidc.issuerUrl=https://auth.example.com \
+  --set mcp.config.oidc.baseUrl=https://kubecost.example.com \
   > "${RENDER_DIR}/oidc-both-creds.yaml"
 pass "helm template succeeds when authMode=oidc with both inline and existingSecret (no mutual-exclusivity guard)"
 

--- a/.github/scripts/validate_mcp_subchart.sh
+++ b/.github/scripts/validate_mcp_subchart.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+#
+# Validates the mcp-kubecost subchart integration in the kubecost chart.
+#
+# Checks performed:
+#   1. Chart.yaml declares mcp-kubecost with a condition, and Chart.lock agrees.
+#   2. The subchart renders nothing by default (opt-in only).
+#   3. helm lint passes with the subchart enabled.
+#   4. The full chart renders and produces the expected mcp-kubecost resources.
+#   5. Parent `global:` values are inherited by the subchart (conformance check).
+#   6. The subchart's Kubecost API base URL points at the rendered frontend Service.
+#
+# Usage (from the repository root):
+#   .github/scripts/validate_mcp_subchart.sh [chart-dir]
+#
+# Requires: helm >= 3.8, yq >= 4.
+set -euo pipefail
+
+CHART_DIR="${1:-kubecost}"
+RELEASE_NAME="kubecost"
+SUBCHART_NAME="mcp-kubecost"
+RENDER_DIR="$(mktemp -d)"
+trap 'rm -rf "$RENDER_DIR"' EXIT
+
+failures=0
+
+pass() { printf '  ok   %s\n' "$1"; }
+fail() {
+  printf '  FAIL %s\n' "$1" >&2
+  printf '::error::%s\n' "$1"
+  failures=$((failures + 1))
+}
+group() { printf '\n==> %s\n' "$1"; }
+
+# assert_eq <description> <expected> <actual>
+assert_eq() {
+  local desc="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    pass "$desc"
+  else
+    fail "$desc (expected '${expected}', got '${actual}')"
+  fi
+}
+
+# assert_contains <description> <file> <fixed-string>
+assert_contains() {
+  local desc="$1" file="$2" needle="$3"
+  if grep -qF -- "$needle" "$file"; then
+    pass "$desc"
+  else
+    fail "$desc (missing '${needle}')"
+  fi
+}
+
+# assert_absent <description> <file> <fixed-string>
+assert_absent() {
+  local desc="$1" file="$2" needle="$3"
+  if grep -qF -- "$needle" "$file"; then
+    fail "$desc (unexpectedly found '${needle}')"
+  else
+    pass "$desc"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+group "Chart metadata"
+
+chart_yaml="${CHART_DIR}/Chart.yaml"
+chart_lock="${CHART_DIR}/Chart.lock"
+
+dep_version="$(yq -r \
+  ".dependencies[] | select(.name == \"${SUBCHART_NAME}\") | .version // \"\"" \
+  "$chart_yaml")"
+dep_repository="$(yq -r \
+  ".dependencies[] | select(.name == \"${SUBCHART_NAME}\") | .repository // \"\"" \
+  "$chart_yaml")"
+dep_condition="$(yq -r \
+  ".dependencies[] | select(.name == \"${SUBCHART_NAME}\") | .condition // \"\"" \
+  "$chart_yaml")"
+dep_alias="$(yq -r \
+  ".dependencies[] | select(.name == \"${SUBCHART_NAME}\") | .alias // \"\"" \
+  "$chart_yaml")"
+
+if [ -z "$dep_version" ]; then
+  fail "${chart_yaml} declares a ${SUBCHART_NAME} dependency"
+  exit 1
+fi
+pass "${chart_yaml} declares ${SUBCHART_NAME} ${dep_version}"
+
+# The values key is the alias when set, otherwise the chart name.
+values_key="${dep_alias:-$SUBCHART_NAME}"
+
+assert_eq "dependency repository is the mcp-kubecost Helm repo" \
+  "https://kubecost.github.io/mcp-kubecost" "$dep_repository"
+assert_eq "dependency condition gates the subchart" \
+  "${values_key}.enabled" "$dep_condition"
+
+if [ "$dep_version" = "*" ] || [ "${dep_version#\^}" != "$dep_version" ] \
+  || [ "${dep_version#\~}" != "$dep_version" ]; then
+  fail "dependency version must be pinned for reproducible builds, got '${dep_version}'"
+else
+  pass "dependency version is pinned"
+fi
+
+lock_version="$(yq -r \
+  ".dependencies[] | select(.name == \"${SUBCHART_NAME}\") | .version // \"\"" \
+  "$chart_lock")"
+assert_eq "${chart_lock} pins the same version as ${chart_yaml}" \
+  "${dep_version#v}" "${lock_version#v}"
+
+default_enabled="$(yq -r ".[\"${values_key}\"].enabled" "${CHART_DIR}/values.yaml")"
+assert_eq "values.yaml defaults ${values_key}.enabled to false" "false" "$default_enabled"
+
+# ---------------------------------------------------------------------------
+group "Dependency resolution (validates Chart.lock is in sync)"
+
+# Set MCP_SUBCHART_SKIP_DEP_BUILD=1 to reuse an already-vendored
+# kubecost/charts/ directory, e.g. when iterating locally without network
+# access. CI must always run the build so Chart.lock is verified.
+if [ "${MCP_SUBCHART_SKIP_DEP_BUILD:-0}" = "1" ]; then
+  printf '  skip helm dependency build (MCP_SUBCHART_SKIP_DEP_BUILD=1)\n'
+else
+  helm dependency build "$CHART_DIR"
+  pass "helm dependency build succeeded (Chart.lock in sync with Chart.yaml)"
+fi
+
+if [ ! -f "${CHART_DIR}/charts/${SUBCHART_NAME}-${dep_version#v}.tgz" ]; then
+  fail "expected ${CHART_DIR}/charts/${SUBCHART_NAME}-${dep_version#v}.tgz to be present"
+else
+  pass "subchart tarball ${SUBCHART_NAME}-${dep_version#v}.tgz present"
+fi
+
+# mcp-kubecost 0.6.0's values.schema.json uses additionalProperties: false and
+# does not declare `enabled`, which Helm injects from Chart.yaml `condition`.
+# Skip JSON-schema validation whenever the subchart is enabled.
+skip_schema=(--skip-schema-validation)
+
+# ---------------------------------------------------------------------------
+group "helm lint"
+
+helm lint "$CHART_DIR"
+pass "helm lint (defaults)"
+
+helm lint "$CHART_DIR" "${skip_schema[@]}" --set "${values_key}.enabled=true"
+pass "helm lint (--set ${values_key}.enabled=true)"
+
+# ---------------------------------------------------------------------------
+group "Subchart is opt-in"
+
+helm template "$RELEASE_NAME" "$CHART_DIR" > "${RENDER_DIR}/default.yaml"
+pass "helm template (defaults) rendered without errors"
+
+# Only look at rendered resource sources, since the diagnostics ConfigMap
+# embeds the full values tree and always mentions the subchart key.
+default_sources="$(grep '^# Source:' "${RENDER_DIR}/default.yaml" || true)"
+# Helm uses the alias (when set) as the on-disk chart directory in # Source: lines.
+if printf '%s\n' "$default_sources" | grep -q "charts/${values_key}/"; then
+  fail "subchart rendered resources while ${values_key}.enabled=false"
+else
+  pass "no subchart resources rendered while ${values_key}.enabled=false"
+fi
+
+# ---------------------------------------------------------------------------
+group "Subchart renders expected resources"
+
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  > "${RENDER_DIR}/enabled.yaml"
+pass "helm template (${values_key}.enabled=true) rendered without errors"
+
+expected_fullname="${RELEASE_NAME}-${values_key}"
+
+for kind in Deployment Service ConfigMap; do
+  found="$(yq -r \
+    "select(.kind == \"${kind}\") | .metadata.name | select(. == \"${expected_fullname}\" or . == \"${expected_fullname}-config\")" \
+    "${RENDER_DIR}/enabled.yaml" | head -1)"
+  if [ -n "$found" ]; then
+    pass "rendered ${kind}/${found}"
+  else
+    fail "expected a ${kind} named ${expected_fullname} (or ${expected_fullname}-config)"
+  fi
+done
+
+# The Deployment must be schedulable and reference the published image.
+mcp_image="$(yq -r \
+  "select(.kind == \"Deployment\" and .metadata.name == \"${expected_fullname}\") | .spec.template.spec.containers[0].image" \
+  "${RENDER_DIR}/enabled.yaml")"
+assert_eq "subchart Deployment uses the pinned appVersion image" \
+  "icr.io/kubecost/mcp-kubecost:${dep_version#v}" "$mcp_image"
+
+svc_port="$(yq -r \
+  "select(.kind == \"Service\" and .metadata.name == \"${expected_fullname}\") | .spec.ports[0].port" \
+  "${RENDER_DIR}/enabled.yaml")"
+assert_eq "subchart Service exposes the MCP port" "3030" "$svc_port"
+
+# ---------------------------------------------------------------------------
+group "Cross-chart wiring"
+
+# The MCP server reads cost data through the frontend Service, so the default
+# kubecostBaseUrl in values.yaml must match what the parent chart actually
+# renders. This catches drift if the frontend Service name or port changes.
+frontend_service="$(yq -r \
+  'select(.kind == "Service" and .spec.selector."app.kubernetes.io/name" == "frontend") | .metadata.name' \
+  "${RENDER_DIR}/enabled.yaml" | head -1)"
+frontend_port="$(yq -r \
+  'select(.kind == "Service" and .spec.selector."app.kubernetes.io/name" == "frontend") | .spec.ports[0].port' \
+  "${RENDER_DIR}/enabled.yaml" | head -1)"
+
+if [ -z "$frontend_service" ] || [ -z "$frontend_port" ]; then
+  fail "could not locate the rendered Kubecost frontend Service"
+else
+  base_url="$(yq -r \
+    "select(.kind == \"ConfigMap\" and .metadata.name == \"${expected_fullname}-config\") | .data.KUBECOST_BASE_URL" \
+    "${RENDER_DIR}/enabled.yaml")"
+  assert_eq "subchart targets the in-cluster Kubecost frontend Service" \
+    "http://${frontend_service}:${frontend_port}" "$base_url"
+fi
+
+# kubecostBaseUrl is a tpl string in values.yaml, so a different release name
+# must rewrite both the frontend Service and the MCP ConfigMap together.
+alt_release="cost-analyzer"
+helm template "$alt_release" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  > "${RENDER_DIR}/alt-release.yaml"
+pass "helm template (release ${alt_release}) rendered without errors"
+
+alt_frontend="$(yq -r \
+  'select(.kind == "Service" and .spec.selector."app.kubernetes.io/name" == "frontend") | .metadata.name' \
+  "${RENDER_DIR}/alt-release.yaml" | head -1)"
+alt_port="$(yq -r \
+  'select(.kind == "Service" and .spec.selector."app.kubernetes.io/name" == "frontend") | .spec.ports[0].port' \
+  "${RENDER_DIR}/alt-release.yaml" | head -1)"
+alt_fullname="${alt_release}-${values_key}"
+alt_base_url="$(yq -r \
+  "select(.kind == \"ConfigMap\" and .metadata.name == \"${alt_fullname}-config\") | .data.KUBECOST_BASE_URL" \
+  "${RENDER_DIR}/alt-release.yaml")"
+assert_eq "subchart BaseUrl follows a non-default release name" \
+  "http://${alt_frontend}:${alt_port}" "$alt_base_url"
+
+# ---------------------------------------------------------------------------
+group "global: values conformance"
+
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set global.imageRegistry=test-registry.io \
+  --set 'global.imagePullSecrets={global-pull-secret}' \
+  --set 'global.additionalLabels.kubecost\.com/conformance=global-labels' \
+  --set 'global.annotations.kubecost\.com/conformance=global-annotations' \
+  --set 'global.podAnnotations.kubecost\.com/conformance=global-pod-annotations' \
+  > "${RENDER_DIR}/globals.yaml"
+pass "helm template with global overrides rendered without errors"
+
+yq -r \
+  "select(.kind == \"Deployment\" and .metadata.name == \"${expected_fullname}\")" \
+  "${RENDER_DIR}/globals.yaml" > "${RENDER_DIR}/globals-deployment.yaml"
+
+overridden_image="$(yq -r '.spec.template.spec.containers[0].image' \
+  "${RENDER_DIR}/globals-deployment.yaml")"
+assert_eq "global.imageRegistry overrides the subchart image registry" \
+  "test-registry.io/kubecost/mcp-kubecost:${dep_version#v}" "$overridden_image"
+
+pull_secret="$(yq -r '.spec.template.spec.imagePullSecrets[0].name' \
+  "${RENDER_DIR}/globals-deployment.yaml")"
+assert_eq "global.imagePullSecrets is inherited by the subchart" \
+  "global-pull-secret" "$pull_secret"
+
+meta_label="$(yq -r '.metadata.labels."kubecost.com/conformance"' \
+  "${RENDER_DIR}/globals-deployment.yaml")"
+assert_eq "global.additionalLabels lands on the subchart Deployment" \
+  "global-labels" "$meta_label"
+
+pod_label="$(yq -r '.spec.template.metadata.labels."kubecost.com/conformance"' \
+  "${RENDER_DIR}/globals-deployment.yaml")"
+assert_eq "global.additionalLabels lands on the subchart pod template" \
+  "global-labels" "$pod_label"
+
+selector_label="$(yq -r '.spec.selector.matchLabels."kubecost.com/conformance"' \
+  "${RENDER_DIR}/globals-deployment.yaml")"
+assert_eq "global.additionalLabels stays out of the immutable selector" \
+  "null" "$selector_label"
+
+meta_annotation="$(yq -r '.metadata.annotations."kubecost.com/conformance"' \
+  "${RENDER_DIR}/globals-deployment.yaml")"
+assert_eq "global.annotations lands on the subchart Deployment" \
+  "global-annotations" "$meta_annotation"
+
+pod_annotation="$(yq -r '.spec.template.metadata.annotations."kubecost.com/conformance"' \
+  "${RENDER_DIR}/globals-deployment.yaml")"
+assert_eq "global.podAnnotations lands on the subchart pod template" \
+  "global-pod-annotations" "$pod_annotation"
+
+# The subchart must keep its own config-reload checksum alongside global annotations.
+checksum="$(yq -r '.spec.template.metadata.annotations."checksum/config"' \
+  "${RENDER_DIR}/globals-deployment.yaml")"
+if [ "$checksum" = "null" ] || [ -z "$checksum" ]; then
+  fail "global.podAnnotations clobbered the subchart's checksum/config annotation"
+else
+  pass "subchart checksum/config annotation survives global.podAnnotations"
+fi
+
+# No stale icr.io reference should remain in the subchart resources once the
+# registry is overridden.
+assert_absent "no hardcoded icr.io in the subchart Deployment after override" \
+  "${RENDER_DIR}/globals-deployment.yaml" "icr.io"
+
+# --- OpenShift adaptation --------------------------------------------------
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set global.platforms.openshift.enabled=true \
+  > "${RENDER_DIR}/openshift.yaml"
+pass "helm template with global.platforms.openshift.enabled=true rendered"
+
+yq -r \
+  "select(.kind == \"Deployment\" and .metadata.name == \"${expected_fullname}\") | .spec.template.spec.securityContext" \
+  "${RENDER_DIR}/openshift.yaml" > "${RENDER_DIR}/openshift-sc.yaml"
+
+ocp_run_as_user="$(yq -r '.runAsUser' "${RENDER_DIR}/openshift-sc.yaml")"
+assert_eq "OpenShift render drops the explicit runAsUser (restricted-v2 SCC)" \
+  "null" "$ocp_run_as_user"
+
+ocp_run_as_non_root="$(yq -r '.runAsNonRoot' "${RENDER_DIR}/openshift-sc.yaml")"
+assert_eq "OpenShift render keeps runAsNonRoot" "true" "$ocp_run_as_non_root"
+
+# Non-OpenShift renders must keep the chart's hardened UID/GID.
+default_run_as_user="$(yq -r \
+  "select(.kind == \"Deployment\" and .metadata.name == \"${expected_fullname}\") | .spec.template.spec.securityContext.runAsUser" \
+  "${RENDER_DIR}/enabled.yaml")"
+assert_eq "default render keeps the subchart's non-root UID" \
+  "65532" "$default_run_as_user"
+
+# --- CI/CD sanity-check bypass --------------------------------------------
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set "${values_key}.enabled=true" \
+  --set global.platforms.cicd.enabled=true \
+  --set global.platforms.cicd.skipSanityChecks=true \
+  --set "${values_key}.config.kubecostApiKey.existingSecret=does-not-exist" \
+  > "${RENDER_DIR}/cicd.yaml"
+pass "global.platforms.cicd.skipSanityChecks lets the subchart render for Argo CD"
+
+assert_contains "subchart reads the API key from the referenced Secret" \
+  "${RENDER_DIR}/cicd.yaml" "name: does-not-exist"
+
+# ---------------------------------------------------------------------------
+group "Summary"
+
+if [ "$failures" -ne 0 ]; then
+  printf '%s check(s) failed.\n' "$failures" >&2
+  exit 1
+fi
+printf 'All mcp-kubecost subchart checks passed.\n'

--- a/.github/workflows/test-chart-3.0.yml
+++ b/.github/workflows/test-chart-3.0.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Run chart-testing (lint)
         run: |
           helm repo add finops-agent-chart https://kubecost.github.io/finops-agent-chart
+          helm repo add mcp-kubecost https://kubecost.github.io/mcp-kubecost
           helm repo update
           helm dependency build kubecost/
           ct lint --chart-dirs=kubecost/ --charts kubecost/ --validate-maintainers=false
@@ -61,6 +62,8 @@ jobs:
 
       - name: Frontend serverBlockConfig template tests
         run: |
+          helm repo add mcp-kubecost https://kubecost.github.io/mcp-kubecost
+          helm repo update
           helm dependency build kubecost/
           .github/scripts/extra_server_config_test.sh
 
@@ -108,6 +111,7 @@ jobs:
         working-directory: ./kubecost
         run: |
           helm repo add finops-agent-chart https://kubecost.github.io/finops-agent-chart
+          helm repo add mcp-kubecost https://kubecost.github.io/mcp-kubecost
           helm repo update
           helm dependency build
           helm install --wait --wait-for-jobs kubecost . -n kubecost
@@ -191,6 +195,7 @@ jobs:
         run: |
           cd ./target-branch/kubecost
           helm repo add finops-agent-chart https://kubecost.github.io/finops-agent-chart
+          helm repo add mcp-kubecost https://kubecost.github.io/mcp-kubecost
           helm repo update
           helm dependency build
           helm install --wait --wait-for-jobs kubecost . -n kubecost
@@ -243,6 +248,7 @@ jobs:
         working-directory: ./kubecost
         run: |
           helm repo add finops-agent-chart https://kubecost.github.io/finops-agent-chart
+          helm repo add mcp-kubecost https://kubecost.github.io/mcp-kubecost
           helm repo update
           helm dependency build
           helm install --wait --wait-for-jobs kubecost . -n kubecost -f values-openshift.yaml \
@@ -302,6 +308,7 @@ jobs:
         working-directory: ./kubecost
         run: |
           helm repo add finops-agent-chart https://kubecost.github.io/finops-agent-chart
+          helm repo add mcp-kubecost https://kubecost.github.io/mcp-kubecost
           helm repo update
           helm dependency build
           helm install --wait --wait-for-jobs kubecost . -n kubecost -f values-eks-cost-monitoring.yaml

--- a/.github/workflows/validate-mcp-subchart.yml
+++ b/.github/workflows/validate-mcp-subchart.yml
@@ -21,7 +21,6 @@ permissions:
 
 env:
   CHART_DIR: kubecost
-  KUBERNETES_VERSION: 1.34.0
 
 jobs:
   validate-mcp-subchart:

--- a/.github/workflows/validate-mcp-subchart.yml
+++ b/.github/workflows/validate-mcp-subchart.yml
@@ -1,0 +1,103 @@
+name: Validate mcp-kubecost subchart
+
+on:
+  pull_request:
+    paths:
+      - 'kubecost/Chart.yaml'
+      - 'kubecost/Chart.lock'
+      - 'kubecost/values.yaml'
+      - '.github/scripts/validate_mcp_subchart.sh'
+      - '.github/workflows/validate-mcp-subchart.yml'
+  workflow_dispatch: {}
+
+# Prevents multiple runs of the same workflow on the same branch from executing
+# simultaneously. Saves resources.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CHART_DIR: kubecost
+  KUBERNETES_VERSION: 1.34.0
+
+jobs:
+  validate-mcp-subchart:
+    name: Lint, render, and check global inheritance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+
+      # ubuntu-latest ships yq, but pin it so assertion syntax cannot drift
+      # when the runner image is updated.
+      - name: Set up yq
+        run: |
+          set -euo pipefail
+          YQ_VERSION=v4.53.4
+          curl -fsSL -o /tmp/yq \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+          sudo install -m 0755 /tmp/yq /usr/local/bin/yq
+          yq --version
+
+      - name: Add chart repositories
+        run: |
+          set -euo pipefail
+          helm repo add finops-agent-chart https://kubecost.github.io/finops-agent-chart
+          helm repo add mcp-kubecost https://kubecost.github.io/mcp-kubecost
+          helm repo update
+
+      # Resolves both dependencies from Chart.lock. This fails loudly if
+      # Chart.lock is out of sync with Chart.yaml, or if the pinned
+      # mcp-kubecost version is not published yet.
+      - name: Build chart dependencies
+        run: helm dependency build "$CHART_DIR"
+
+      # helm lint with the subchart enabled, helm template for the default and
+      # enabled cases, resource assertions, and the global: conformance checks.
+      - name: Validate mcp-kubecost subchart integration
+        run: .github/scripts/validate_mcp_subchart.sh "$CHART_DIR"
+
+      - name: Render charts for schema validation
+        run: |
+          set -euo pipefail
+          mkdir -p .helm-render
+          helm template kubecost "$CHART_DIR" \
+            --skip-schema-validation \
+            --set mcp.enabled=true \
+            > .helm-render/mcp-enabled.yaml
+          helm template kubecost "$CHART_DIR" \
+            --skip-schema-validation \
+            --set mcp.enabled=true \
+            --set mcp.httpRoute.enabled=true \
+            --set mcp.config.kubecostApiKey.existingSecret=kubecost-api-key \
+            --set global.platforms.cicd.enabled=true \
+            --set global.platforms.cicd.skipSanityChecks=true \
+            > .helm-render/mcp-httproute.yaml
+
+      # Ensure every rendered resource is valid Kubernetes YAML. HTTPRoute is a
+      # Gateway API CRD, so that render tolerates missing schemas.
+      - name: Kubeconform (core resources)
+        uses: docker://ghcr.io/yannh/kubeconform:latest
+        with:
+          entrypoint: /kubeconform
+          args: -summary -strict -kubernetes-version 1.34.0 -ignore-missing-schemas -output text .helm-render/mcp-enabled.yaml
+
+      - name: Kubeconform (HTTPRoute render)
+        uses: docker://ghcr.io/yannh/kubeconform:latest
+        with:
+          entrypoint: /kubeconform
+          args: -summary -kubernetes-version 1.34.0 -ignore-missing-schemas -output text .helm-render/mcp-httproute.yaml
+
+      - name: Upload rendered manifests
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mcp-subchart-renders
+          path: .helm-render/
+          if-no-files-found: warn

--- a/.github/workflows/validate-mcp-subchart.yml
+++ b/.github/workflows/validate-mcp-subchart.yml
@@ -6,6 +6,9 @@ on:
       - 'kubecost/Chart.yaml'
       - 'kubecost/Chart.lock'
       - 'kubecost/values.yaml'
+      - 'kubecost/templates/_helpers.tpl'
+      - 'kubecost/templates/frontend/_helpers.tpl'
+      - 'kubecost/templates/frontend/frontend-configmap.yaml'
       - '.github/scripts/validate_mcp_subchart.sh'
       - '.github/workflows/validate-mcp-subchart.yml'
   workflow_dispatch: {}
@@ -60,6 +63,8 @@ jobs:
       # helm lint with the subchart enabled, helm template for the default and
       # enabled cases, resource assertions, and the global: conformance checks.
       - name: Validate mcp-kubecost subchart integration
+        env:
+          MCP_SUBCHART_SKIP_DEP_BUILD: "1"
         run: .github/scripts/validate_mcp_subchart.sh "$CHART_DIR"
 
       - name: Render charts for schema validation

--- a/.github/workflows/validate-mcp-subchart.yml
+++ b/.github/workflows/validate-mcp-subchart.yml
@@ -80,6 +80,7 @@ jobs:
             --skip-schema-validation \
             --set mcp.enabled=true \
             --set mcp.httpRoute.enabled=true \
+            --set mcp.config.authMode=open \
             --set mcp.config.kubecostApiKey.existingSecret=kubecost-api-key \
             --set global.platforms.cicd.enabled=true \
             --set global.platforms.cicd.skipSanityChecks=true \

--- a/.github/workflows/validate-mcp-subchart.yml
+++ b/.github/workflows/validate-mcp-subchart.yml
@@ -7,6 +7,7 @@ on:
       - 'kubecost/Chart.lock'
       - 'kubecost/values.yaml'
       - 'kubecost/templates/_helpers.tpl'
+      - 'kubecost/templates/NOTES.txt'
       - 'kubecost/templates/frontend/_helpers.tpl'
       - 'kubecost/templates/frontend/frontend-configmap.yaml'
       - '.github/scripts/validate_mcp_subchart.sh'
@@ -83,6 +84,12 @@ jobs:
             --set global.platforms.cicd.enabled=true \
             --set global.platforms.cicd.skipSanityChecks=true \
             > .helm-render/mcp-httproute.yaml
+          helm template kubecost "$CHART_DIR" \
+            --skip-schema-validation \
+            --set mcp.enabled=true \
+            --set mcp.httpRoute.enabled=true \
+            --set mcp.config.authMode=open \
+            > .helm-render/mcp-httproute-open.yaml
 
       # Ensure every rendered resource is valid Kubernetes YAML. HTTPRoute is a
       # Gateway API CRD, so that render tolerates missing schemas.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,5 @@
 # Agents.md
 
-## GitHub Actions
-
-- Never downgrade (or change) a GitHub Actions version without first verifying the version exists. Use `execute_command` to look it up: `curl -s https://api.github.com/repos/<owner>/<repo>/git/refs/tags | grep '"ref"' | grep '@v<N>'` or check the GitHub Marketplace page. Do not assume a version does not exist based on training knowledge alone.
-- when a GitHub Action is modified, verify that all actions in the workflow are current and use online lookups, do not depend on stale training data. If a new version is available, always suggest updating it.
-
 ## PR Reviews
 
 - When asked to review a PR, compare this current branch against the `develop` branch. `git diff develop`.
@@ -29,3 +24,7 @@ helm dependency build ./kubecost
 # Templating
 helm template kubecost ./kubecost
 ```
+
+## Additional rules
+
+Always check for rules that agents must follow in the [.bob/rules](.bob/rules) folder.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,9 @@
 # Agents.md
 
+## GitHub Actions
+
+- Never downgrade (or change) a GitHub Actions version without first verifying the version exists. Use `execute_command` to look it up: `curl -s https://api.github.com/repos/<owner>/<repo>/git/refs/tags | grep '"ref"' | grep '@v<N>'` or check the GitHub Marketplace page. Do not assume a version does not exist based on training knowledge alone.
+
 ## PR Reviews
 
 - When asked to review a PR, compare this current branch against the `develop` branch. `git diff develop`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## GitHub Actions
 
 - Never downgrade (or change) a GitHub Actions version without first verifying the version exists. Use `execute_command` to look it up: `curl -s https://api.github.com/repos/<owner>/<repo>/git/refs/tags | grep '"ref"' | grep '@v<N>'` or check the GitHub Marketplace page. Do not assume a version does not exist based on training knowledge alone.
+- when a GitHub Action is modified, verify that all actions in the workflow are current and use online lookups, do not depend on stale training data. If a new version is available, always suggest updating it.
 
 ## PR Reviews
 

--- a/kubecost/Chart.lock
+++ b/kubecost/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.25
 - name: mcp-kubecost
   repository: https://kubecost.github.io/mcp-kubecost
-  version: 0.6.3
-digest: sha256:db0c1cb0ba4149ecd66511d40eb9abb79b667ea20e5527ad5994702dca1f5841
-generated: "2026-08-20T15:50:47.172036-04:00"
+  version: 0.7.0
+digest: sha256:82acc3c530c558525991ce331801204cf504ce542d0f5a57ba130e31bd24e214
+generated: "2026-08-24T16:05:14.749925-04:00"

--- a/kubecost/Chart.lock
+++ b/kubecost/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.25
 - name: mcp-kubecost
   repository: https://kubecost.github.io/mcp-kubecost
-  version: 0.6.2
-digest: sha256:901ac93d9280930e218d97d36982248a546d1d4d5d5bcf37ee2356da8aceb920
-generated: "2026-08-19T20:13:30.510304-04:00"
+  version: 0.6.3
+digest: sha256:db0c1cb0ba4149ecd66511d40eb9abb79b667ea20e5527ad5994702dca1f5841
+generated: "2026-08-20T15:50:47.172036-04:00"

--- a/kubecost/Chart.lock
+++ b/kubecost/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.25
 - name: mcp-kubecost
   repository: https://kubecost.github.io/mcp-kubecost
-  version: 0.7.0
-digest: sha256:82acc3c530c558525991ce331801204cf504ce542d0f5a57ba130e31bd24e214
-generated: "2026-08-24T16:05:14.749925-04:00"
+  version: 0.9.0
+digest: sha256:6f168f3291bbebdc96144bb9223a1bf6d5cd8a242227ea7e35677e038896babd
+generated: "2026-08-25T16:34:57.820416-04:00"

--- a/kubecost/Chart.lock
+++ b/kubecost/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: finops-agent
   repository: https://kubecost.github.io/finops-agent-chart
   version: 1.0.25
-digest: sha256:7fd9a8b7cd18e294d91f0deba3eab25b1dd57853fefa990c46dbd2d025337c54
-generated: "2026-08-07T12:01:56.903313-07:00"
+- name: mcp-kubecost
+  repository: https://kubecost.github.io/mcp-kubecost
+  version: 0.6.1
+digest: sha256:83a70fb254de820a4f9f263ee609b62fb7c668a2e1e6e75a7d7879d0fc0d96a6
+generated: "2026-08-19T17:13:43.189637-04:00"

--- a/kubecost/Chart.lock
+++ b/kubecost/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.0.25
 - name: mcp-kubecost
   repository: https://kubecost.github.io/mcp-kubecost
-  version: 0.6.1
-digest: sha256:83a70fb254de820a4f9f263ee609b62fb7c668a2e1e6e75a7d7879d0fc0d96a6
-generated: "2026-08-19T17:13:43.189637-04:00"
+  version: 0.6.2
+digest: sha256:901ac93d9280930e218d97d36982248a546d1d4d5d5bcf37ee2356da8aceb920
+generated: "2026-08-19T20:13:30.510304-04:00"

--- a/kubecost/Chart.yaml
+++ b/kubecost/Chart.yaml
@@ -14,11 +14,11 @@ dependencies:
     version: "v1.0.25"
     repository: https://kubecost.github.io/finops-agent-chart
     condition: finopsagent.enabled
-  # The FinOps MCP server for Kubecost analytics. Disabled by default; the pinned
+  # The FinOps MCP server for Kubecost analytics. Enabled by default; the pinned
   # version is bumped automatically by the mcp-kubecost release pipeline.
   # Ref: https://github.com/kubecost/mcp-kubecost
   - name: mcp-kubecost
     alias: mcp
-    version: "0.6.2"
+    version: "0.6.3"
     repository: https://kubecost.github.io/mcp-kubecost
     condition: mcp.enabled

--- a/kubecost/Chart.yaml
+++ b/kubecost/Chart.yaml
@@ -19,6 +19,6 @@ dependencies:
   # Ref: https://github.com/kubecost/mcp-kubecost
   - name: mcp-kubecost
     alias: mcp
-    version: "0.6.3"
+    version: "0.7.0"
     repository: https://kubecost.github.io/mcp-kubecost
     condition: mcp.enabled

--- a/kubecost/Chart.yaml
+++ b/kubecost/Chart.yaml
@@ -19,6 +19,6 @@ dependencies:
   # Ref: https://github.com/kubecost/mcp-kubecost
   - name: mcp-kubecost
     alias: mcp
-    version: "0.6.1"
+    version: "0.6.2"
     repository: https://kubecost.github.io/mcp-kubecost
     condition: mcp.enabled

--- a/kubecost/Chart.yaml
+++ b/kubecost/Chart.yaml
@@ -14,3 +14,11 @@ dependencies:
     version: "v1.0.25"
     repository: https://kubecost.github.io/finops-agent-chart
     condition: finopsagent.enabled
+  # The FinOps MCP server for Kubecost analytics. Disabled by default; the pinned
+  # version is bumped automatically by the mcp-kubecost release pipeline.
+  # Ref: https://github.com/kubecost/mcp-kubecost
+  - name: mcp-kubecost
+    alias: mcp
+    version: "0.6.1"
+    repository: https://kubecost.github.io/mcp-kubecost
+    condition: mcp.enabled

--- a/kubecost/Chart.yaml
+++ b/kubecost/Chart.yaml
@@ -19,6 +19,6 @@ dependencies:
   # Ref: https://github.com/kubecost/mcp-kubecost
   - name: mcp-kubecost
     alias: mcp
-    version: "0.7.0"
+    version: "0.9.0"
     repository: https://kubecost.github.io/mcp-kubecost
     condition: mcp.enabled

--- a/kubecost/templates/NOTES.txt
+++ b/kubecost/templates/NOTES.txt
@@ -47,5 +47,5 @@ Copyright IBM Corp. 2019-2026
 
 {{- include "kubecost.localStoreClusterIdCheck" . -}}
 {{- include "kubecost.v3-postconditions" . -}}
-{{- include "kubecost.mcp.apiKeyAuthCheck" . -}}
 {{- include "kubecost.mcp.openRouteCheck" . -}}
+{{- include "kubecost.mcp.validateOIDC" . -}}

--- a/kubecost/templates/NOTES.txt
+++ b/kubecost/templates/NOTES.txt
@@ -12,7 +12,7 @@
 {{- include "kubecost.cloudCost.persistentStorage.check" . -}}
 {{- include "kubecost.aggregator.storageCheck" . -}}
 {{- include "kubecost.aggregator.storageWarning" . }}
-{{- include "kubecost.mcp.apiKeyAuthCheck" . -}}
+
 ================================================================================
 KUBECOST INSTALLATION SUCCESSFUL
 ================================================================================
@@ -47,3 +47,4 @@ Copyright IBM Corp. 2019-2026
 
 {{- include "kubecost.localStoreClusterIdCheck" . -}}
 {{- include "kubecost.v3-postconditions" . -}}
+{{- include "kubecost.mcp.apiKeyAuthCheck" . -}}

--- a/kubecost/templates/NOTES.txt
+++ b/kubecost/templates/NOTES.txt
@@ -12,6 +12,7 @@
 {{- include "kubecost.cloudCost.persistentStorage.check" . -}}
 {{- include "kubecost.aggregator.storageCheck" . -}}
 {{- include "kubecost.aggregator.storageWarning" . }}
+{{- include "kubecost.mcp.apiKeyAuthCheck" . -}}
 ================================================================================
 KUBECOST INSTALLATION SUCCESSFUL
 ================================================================================

--- a/kubecost/templates/NOTES.txt
+++ b/kubecost/templates/NOTES.txt
@@ -48,3 +48,4 @@ Copyright IBM Corp. 2019-2026
 {{- include "kubecost.localStoreClusterIdCheck" . -}}
 {{- include "kubecost.v3-postconditions" . -}}
 {{- include "kubecost.mcp.apiKeyAuthCheck" . -}}
+{{- include "kubecost.mcp.openRouteCheck" . -}}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -600,6 +600,46 @@ To resolve this, either:
 {{- end -}}
 
 {{/*
+Path prefix the MCP server is served under on the Kubecost frontend host,
+derived from the path component of mcp.config.oidc.baseUrl. Empty when the MCP
+server has its own hostname (baseUrl at a host root) or when OIDC is off.
+
+When non-empty, FastMCP advertises {baseUrl}/authorize, {baseUrl}/token and
+{baseUrl}/register in its OAuth metadata, so every OAuth path the MCP clients
+touch lives under this prefix instead of the shared host root. The frontend
+nginx strips the prefix before proxying, and the subchart serves the MCP
+endpoint at "/" to match (mcp-kubecost.httpPath).
+
+Rejects characters that are not safe to interpolate into the nginx rewrite
+regexes that consume this value.
+*/}}
+{{- define "kubecost.mcp.pathPrefix" -}}
+{{- $raw := ((((.Values.mcp).config).oidc).baseUrl) | default "" | trim -}}
+{{- if $raw -}}
+{{- $path := (urlParse $raw).path | default "" -}}
+{{- $path = printf "/%s" (trimAll "/" $path) -}}
+{{- if ne $path "/" -}}
+{{- if not (regexMatch "^(/[A-Za-z0-9._~-]+)+$" $path) -}}
+{{- fail (printf "\n\nFAILURE [kubecost / mcp]: the path in mcp.config.oidc.baseUrl (%q) is not a usable nginx location prefix. Use only unreserved URL characters, e.g. https://kubecost.example.com/mcp\n" $path) -}}
+{{- end -}}
+{{- $path -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubecost.mcp.kubecostApiBaseUrl" -}}
+{{- tpl (default (printf "http://%s-aggregator" .Release.Name) ((.Values.mcp).config).kubecostApiBaseUrl) . -}}
+{{- end -}}
+
+{{- define "kubecost.mcp.kubecostApiPort" -}}
+{{- default 9004 ((.Values.mcp).config).kubecostApiPort -}}
+{{- end -}}
+
+{{- define "kubecost.mcp.kubecostApiBasePath" -}}
+{{- default "/" ((.Values.mcp).config).kubecostApiBasePath -}}
+{{- end -}}
+
+{{/*
 Service name of the mcp-kubecost subchart. Mirrors mcp-kubecost.fullname so the
 frontend nginx upstream targets the same Service the subchart renders.
 */}}
@@ -621,43 +661,21 @@ frontend nginx upstream targets the same Service the subchart renders.
 {{- end -}}
 
 {{/*
-Fail when MCP holds a Kubecost API key but the MCP HTTP endpoint is not
-protected with OIDC. When CI/CD skipSanityChecks is set, emit a warning instead.
-*/}}
-{{- define "kubecost.mcp.apiKeyAuthCheck" -}}
-{{- $hasKeyValue := (((.Values.mcp).config).kubecostApiKey).value -}}
-{{- $hasKeySecret := (((.Values.mcp).config).kubecostApiKey).existingSecret -}}
-{{- if and (.Values.mcp).enabled (or $hasKeyValue $hasKeySecret) }}
-{{- $authMode := include "kubecost.mcp.authMode" . -}}
-{{- if and (ne $authMode "oidc") (ne $authMode "api_key") }}
-{{- if and .Values.global.platforms.cicd.enabled .Values.global.platforms.cicd.skipSanityChecks }}
-
-WARNING: MCP.CONFIG.KUBECOSTAPIKEY IS SET BUT MCP.CONFIG.AUTHMODE IS NOT "OIDC" OR "API_KEY". THIS IS
-NOT SECURE: THE MCP SERVER HOLDS A KUBECOST API KEY WHILE THE MCP HTTP ENDPOINT IS NOT PROTECTED.
-SET MCP.CONFIG.AUTHMODE TO OIDC OR API_KEY, OR CLEAR THE API KEY.
-SKIPSANITYCHECKS IS TRUE SO THIS CHECK DID NOT FAIL.
-{{- else }}
-{{- fail "\n\nFAILURE: mcp.config.kubecostApiKey is set but mcp.config.authMode is not \"oidc\" or \"api_key\". This is not secure: the MCP server holds a Kubecost API key while the MCP HTTP endpoint is not protected. Set mcp.config.authMode to oidc or api_key, or clear the API key\n" }}
-{{- end }}
-{{- end }}
-{{- end }}
-{{- end -}}
-
-{{/*
 Fail when authMode is "none" and either an MCP route (httpRoute or ingress) is
 enabled, or kubecostApiPort is 9008 (aggregator SSO bypass). In both cases the
 MCP endpoint would be unauthenticated while able to reach Kubecost without
 SSO. When CI/CD skipSanityChecks is set, emit a warning instead.
+This does not prevent an mcp.httpRoute or mcp.ingress from being enabled. Those checks exist in the sub-chart itself.
 */}}
 {{- define "kubecost.mcp.openRouteCheck" -}}
 {{- if (.Values.mcp).enabled }}
-{{- $routeEnabled := or ((.Values.mcp).httpRoute).enabled ((.Values.mcp).ingress).enabled -}}
-{{- $apiPort := toString (default 9004 ((.Values.mcp).config).kubecostApiPort) -}}
+{{- $routeEnabled := or ((.Values.mcp).httpRoute).enabled ((.Values.mcp).ingress).enabled (.Values.ingress).enabled (.Values.httpRoute).enabled -}}
+{{- $apiPort := toString (include "kubecost.mcp.kubecostApiPort" .) -}}
 {{- $authMode := include "kubecost.mcp.authMode" . -}}
 {{- if and (or $routeEnabled (eq $apiPort "9008")) (eq $authMode "none") }}
 {{- if and .Values.global.platforms.cicd.enabled .Values.global.platforms.cicd.skipSanityChecks }}
 
-WARNING: MCP.CONFIG.AUTHMODE IS "NONE" WHILE MCP.HTTPROUTE/INGRESS IS ENABLED OR MCP.CONFIG.KUBECOSTAPIPORT IS 9008.
+WARNING: MCP.CONFIG.AUTHMODE IS "NONE" WHILE an HTTPROUTE/INGRESS IS ENABLED OR MCP.CONFIG.KUBECOSTAPIPORT IS 9008.
 THE MCP ENDPOINT WOULD BE UNPROTECTED WHILE ABLE TO BYPASS KUBECOST SSO. SET MCP.CONFIG.AUTHMODE TO AT LEAST "OPEN"
 TO ACKNOWLEDGE THIS, OR USE "OIDC" OR "API_KEY" TO ENFORCE AUTHENTICATION.
 SKIPSANITYCHECKS IS TRUE SO THIS CHECK DID NOT FAIL.
@@ -666,6 +684,68 @@ SKIPSANITYCHECKS IS TRUE SO THIS CHECK DID NOT FAIL.
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end -}}
+
+{{/*
+Fail when MCP is enabled, authMode is "oidc", but no OIDC credentials are supplied.
+Valid credential state = either (clientId AND clientSecret both non-empty)
+OR existingSecret non-empty. When CI/CD skipSanityChecks is set, emit a warning instead.
+
+CONCERNS:
+- No mutual-exclusivity guard: supplying both existingSecret and inline clientId/clientSecret
+  will not fail here. The subchart favours existingSecret at runtime but still renders the
+  inline values into a Kubernetes Secret (secret sprawl). This is intentional.
+- Presence != validity: whitespace-only strings pass this check. Runtime OIDC token exchange
+  is the real validation gate.
+- mcp.config.oidc.existingSecret was not in this chart's values.yaml historically. It was
+  added alongside this check so it is now discoverable. The subchart passes it through to the
+  pod via its own Secret-wiring logic.
+- The parent chart only passes through a subset of the subchart's oidc config keys. Operators
+  who need the full OIDC surface (audience, requiredScopes, authIngress.*) must add values
+  under mcp.config.oidc.* directly.
+- Ordering: this check runs during the parent chart's NOTES.txt render. The subchart's own
+  mcp-kubecost.validateOIDC also runs (via its NOTES.txt). Both fire independently when both
+  are misconfigured — this is intentional redundancy, not a bug.
+*/}}
+{{- define "kubecost.mcp.validateOIDC" -}}
+{{- if (.Values.mcp).enabled -}}
+{{- $mode := default "none" ((.Values.mcp).config).authMode -}}
+{{- if eq $mode "oidc" -}}
+{{- $oidc := (((.Values.mcp).config).oidc) | default dict -}}
+{{- $hasInline := and $oidc.clientId $oidc.clientSecret -}}
+{{- $hasExisting := $oidc.existingSecret -}}
+{{- if not (or $hasInline $hasExisting) -}}
+{{- if and .Values.global.platforms.cicd.enabled .Values.global.platforms.cicd.skipSanityChecks }}
+
+WARNING: MCP.CONFIG.AUTHMODE IS "OIDC" BUT NO OIDC CREDENTIALS ARE CONFIGURED.
+SET MCP.CONFIG.OIDC.CLIENTID AND MCP.CONFIG.OIDC.CLIENTSECRET, OR SET MCP.CONFIG.OIDC.EXISTINGSECRET.
+SKIPSANITYCHECKS IS TRUE SO THIS CHECK DID NOT FAIL.
+{{- else }}
+{{- fail "\n\nFAILURE [kubecost / mcp]: mcp.config.authMode is \"oidc\" but no OIDC credentials are configured.\n\nTo fix, choose one of:\n  Option A — inline credentials:\n    mcp.config.oidc.clientId: \"<your-client-id>\"\n    mcp.config.oidc.clientSecret: \"<your-client-secret>\"\n\n  Option B — reference a pre-existing Secret (required keys: OIDC_CLIENT_ID, OIDC_CLIENT_SECRET):\n    mcp.config.oidc.existingSecret: \"<secret-name>\"\n\n  Option C — skip this sanity check (CI/CD only; the MCP OIDC deployment will still be broken until credentials are set):\n    global.platforms.cicd.enabled: true\n    global.platforms.cicd.skipSanityChecks: true\n" }}
+{{- end }}
+{{- end -}}
+{{- if not (hasPrefix "https://" ($oidc.issuerUrl | default "")) -}}
+{{- if and .Values.global.platforms.cicd.enabled .Values.global.platforms.cicd.skipSanityChecks }}
+
+WARNING: MCP.CONFIG.OIDC.ISSUERURL MUST BE SET TO AN HTTPS:// URL.
+EXAMPLE: mcp.config.oidc.issuerUrl: "https://kubecost.example.com/.well-known/openid-configuration"
+SKIPSANITYCHECKS IS TRUE SO THIS CHECK DID NOT FAIL.
+{{- else }}
+{{- fail "\n\nFAILURE [kubecost / mcp]: mcp.config.oidc.issuerUrl must be set to an https:// URL.\n\n  Example:\n    mcp.config.oidc.issuerUrl: \"https://kubecost.example.com/.well-known/openid-configuration\"\n\n  To skip this check (CI/CD only):\n    global.platforms.cicd.enabled: true\n    global.platforms.cicd.skipSanityChecks: true\n" }}
+{{- end }}
+{{- end -}}
+{{- if not (hasPrefix "https://" ($oidc.baseUrl | default "")) -}}
+{{- if and .Values.global.platforms.cicd.enabled .Values.global.platforms.cicd.skipSanityChecks }}
+
+WARNING: MCP.CONFIG.OIDC.BASEURL MUST BE SET TO AN HTTPS:// URL.
+EXAMPLE: mcp.config.oidc.baseUrl: "https://kubecost.example.com"
+SKIPSANITYCHECKS IS TRUE SO THIS CHECK DID NOT FAIL.
+{{- else }}
+{{- fail "\n\nFAILURE [kubecost / mcp]: mcp.config.oidc.baseUrl must be set to an https:// URL.\n\n  Example:\n    mcp.config.oidc.baseUrl: \"https://kubecost.example.com\"\n\n  To skip this check (CI/CD only):\n    global.platforms.cicd.enabled: true\n    global.platforms.cicd.skipSanityChecks: true\n" }}
+{{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{- /*

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -584,7 +584,7 @@ To resolve this, either:
 {{- end -}}
 
 {{- define "kubecost.mcp.authMode" -}}
-{{- default "none" (((.Values.mcp).config).oidc).authMode -}}
+{{- default "none" ((.Values.mcp).config).authMode -}}
 {{- end -}}
 
 {{- define "kubecost.mcp.requireClientApiKey" }}
@@ -632,9 +632,12 @@ protected with OIDC. When CI/CD skipSanityChecks is set, emit a warning instead.
 {{- if and (ne $authMode "oidc") (ne $authMode "both") (ne $authMode "api_key") }}
 {{- if and .Values.global.platforms.cicd.enabled .Values.global.platforms.cicd.skipSanityChecks }}
 
-WARNING: MCP.CONFIG.KUBECOSTAPIKEY IS SET BUT MCP.CONFIG.OIDC.AUTHMODE IS NOT "OIDC", "BOTH", OR "API_KEY". THIS IS NOT SECURE: THE MCP SERVER HOLDS A KUBECOST API KEY WHILE THE MCP HTTP ENDPOINT IS NOT PROTECTED. SET MCP.CONFIG.OIDC.AUTHMODE TO OIDC, BOTH, OR API_KEY, OR CLEAR THE API KEY. SKIPSANITYCHECKS IS TRUE SO THIS CHECK DID NOT FAIL.
+WARNING: MCP.CONFIG.KUBECOSTAPIKEY IS SET BUT MCP.CONFIG.AUTHMODE IS NOT "OIDC", "BOTH", OR "API_KEY". THIS IS
+NOT SECURE: THE MCP SERVER HOLDS A KUBECOST API KEY WHILE THE MCP HTTP ENDPOINT IS NOT PROTECTED.
+SET MCP.CONFIG.AUTHMODE TO OIDC, BOTH, OR API_KEY, OR CLEAR THE API KEY.
+SKIPSANITYCHECKS IS TRUE SO THIS CHECK DID NOT FAIL.
 {{- else }}
-{{- fail "\n\nFAILURE: mcp.config.kubecostApiKey is set but mcp.config.oidc.authMode is not \"oidc\", \"both\", or \"api_key\". This is not secure: the MCP server holds a Kubecost API key while the MCP HTTP endpoint is not protected. Set mcp.config.oidc.authMode to oidc, both, or api_key, or clear the API key\n" }}
+{{- fail "\n\nFAILURE: mcp.config.kubecostApiKey is set but mcp.config.authMode is not \"oidc\", \"both\", or \"api_key\". This is not secure: the MCP server holds a Kubecost API key while the MCP HTTP endpoint is not protected. Set mcp.config.authMode to oidc, both, or api_key, or clear the API key\n" }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -614,6 +614,7 @@ Rejects characters that are not safe to interpolate into the nginx rewrite
 regexes that consume this value.
 */}}
 {{- define "kubecost.mcp.pathPrefix" -}}
+{{- if eq (include "kubecost.mcp.authMode" .) "oidc" -}}
 {{- $raw := ((((.Values.mcp).config).oidc).baseUrl) | default "" | trim -}}
 {{- if $raw -}}
 {{- $path := (urlParse $raw).path | default "" -}}
@@ -623,6 +624,7 @@ regexes that consume this value.
 {{- fail (printf "\n\nFAILURE [kubecost / mcp]: the path in mcp.config.oidc.baseUrl (%q) is not a usable nginx location prefix. Use only unreserved URL characters, e.g. https://kubecost.example.com/mcp\n" $path) -}}
 {{- end -}}
 {{- $path -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -661,10 +663,11 @@ frontend nginx upstream targets the same Service the subchart renders.
 {{- end -}}
 
 {{/*
-Fail when authMode is "none" and either an MCP route (httpRoute or ingress) is
-enabled, or kubecostApiPort is 9008 (aggregator SSO bypass). In both cases the
-MCP endpoint would be unauthenticated while able to reach Kubecost without
-SSO. When CI/CD skipSanityChecks is set, emit a warning instead.
+Fail when authMode is "none" AND a route (httpRoute or ingress) is exposed AND
+kubecostApiPort is 9008 (aggregator SSO bypass). All three conditions must be
+true simultaneously: a route alone at the default port (9004) is permitted, and
+port 9008 alone without an exposed route is also permitted. When CI/CD
+skipSanityChecks is set, emit a warning instead of failing.
 This does not prevent an mcp.httpRoute or mcp.ingress from being enabled. Those checks exist in the sub-chart itself.
 */}}
 {{- define "kubecost.mcp.openRouteCheck" -}}
@@ -672,15 +675,15 @@ This does not prevent an mcp.httpRoute or mcp.ingress from being enabled. Those 
 {{- $routeEnabled := or ((.Values.mcp).httpRoute).enabled ((.Values.mcp).ingress).enabled (.Values.ingress).enabled (.Values.httpRoute).enabled -}}
 {{- $apiPort := toString (include "kubecost.mcp.kubecostApiPort" .) -}}
 {{- $authMode := include "kubecost.mcp.authMode" . -}}
-{{- if and (or $routeEnabled (eq $apiPort "9008")) (eq $authMode "none") }}
+{{- if and  ($routeEnabled) (eq $apiPort "9008") (eq $authMode "none") }}
 {{- if and .Values.global.platforms.cicd.enabled .Values.global.platforms.cicd.skipSanityChecks }}
 
-WARNING: MCP.CONFIG.AUTHMODE IS "NONE" WHILE an HTTPROUTE/INGRESS IS ENABLED OR MCP.CONFIG.KUBECOSTAPIPORT IS 9008.
+WARNING: MCP.CONFIG.AUTHMODE IS "NONE" WHILE an HTTPROUTE/INGRESS IS ENABLED AND MCP.CONFIG.KUBECOSTAPIPORT IS 9008.
 THE MCP ENDPOINT WOULD BE UNPROTECTED WHILE ABLE TO BYPASS KUBECOST SSO. SET MCP.CONFIG.AUTHMODE TO AT LEAST "OPEN"
 TO ACKNOWLEDGE THIS, OR USE "OIDC" OR "API_KEY" TO ENFORCE AUTHENTICATION.
 SKIPSANITYCHECKS IS TRUE SO THIS CHECK DID NOT FAIL.
 {{- else }}
-{{- fail "\n\nFAILURE: mcp.config.authMode is \"none\" while mcp.httpRoute or mcp.ingress is enabled, or mcp.config.kubecostApiPort is 9008. The MCP endpoint would be unauthenticated while it can bypass Kubecost SSO on port 9008. Set mcp.config.authMode to at least \"open\" to acknowledge intentional unauthenticated exposure, or use \"oidc\" or \"api_key\" to enforce authentication.\n" }}
+{{- fail "\n\nFAILURE: mcp.config.authMode is \"none\" while mcp.httpRoute or mcp.ingress is enabled, AND mcp.config.kubecostApiPort is 9008. The MCP endpoint would be unauthenticated while it can bypass Kubecost SSO on port 9008. Set mcp.config.authMode to at least \"open\" to acknowledge intentional unauthenticated exposure, or use \"oidc\" or \"api_key\" to enforce authentication.\n" }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -575,6 +575,71 @@ To resolve this, either:
 {{- end -}}
 {{- end -}}
 
+{{- define "kubecost.mcp.enabled" }}
+{{- if (.Values.mcp).enabled }}
+{{- printf "true" -}}
+{{- else -}}
+{{- printf "false" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubecost.mcp.authMode" -}}
+{{- default "none" (((.Values.mcp).config).oidc).authMode -}}
+{{- end -}}
+
+{{- define "kubecost.mcp.requireClientApiKey" }}
+{{- if ((.Values.mcp).config).requireClientApiKey }}
+{{- printf "true" -}}
+{{- else -}}
+{{- printf "false" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubecost.mcp.redirectPath" -}}
+{{- default "/auth-mcp" (((.Values.mcp).config).oidc).redirectPath -}}
+{{- end -}}
+
+{{/*
+Service name of the mcp-kubecost subchart. Mirrors mcp-kubecost.fullname so the
+frontend nginx upstream targets the same Service the subchart renders.
+*/}}
+{{- define "kubecost.mcp.serviceName" -}}
+{{- if ((.Values.mcp).fullnameOverride) -}}
+{{- .Values.mcp.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "mcp" (.Values.mcp).nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubecost.mcp.servicePort" -}}
+{{- default 3030 ((.Values.mcp).service).port -}}
+{{- end -}}
+
+{{/*
+Fail when MCP holds a Kubecost API key but the MCP HTTP endpoint is not
+protected with OIDC. When CI/CD skipSanityChecks is set, emit a warning instead.
+*/}}
+{{- define "kubecost.mcp.apiKeyAuthCheck" -}}
+{{- $hasKeyValue := (((.Values.mcp).config).kubecostApiKey).value -}}
+{{- $hasKeySecret := (((.Values.mcp).config).kubecostApiKey).existingSecret -}}
+{{- if and (.Values.mcp).enabled (or $hasKeyValue $hasKeySecret) }}
+{{- $authMode := include "kubecost.mcp.authMode" . -}}
+{{- if and (ne $authMode "oidc") (ne $authMode "both") (ne $authMode "api_key") }}
+{{- if and .Values.global.platforms.cicd.enabled .Values.global.platforms.cicd.skipSanityChecks }}
+
+WARNING: MCP.CONFIG.KUBECOSTAPIKEY IS SET BUT MCP.CONFIG.OIDC.AUTHMODE IS NOT "OIDC", "BOTH", OR "API_KEY". THIS IS NOT SECURE: THE MCP SERVER HOLDS A KUBECOST API KEY WHILE THE MCP HTTP ENDPOINT IS NOT PROTECTED. SET MCP.CONFIG.OIDC.AUTHMODE TO OIDC, BOTH, OR API_KEY, OR CLEAR THE API KEY. SKIPSANITYCHECKS IS TRUE SO THIS CHECK DID NOT FAIL.
+{{- else }}
+{{- fail "\n\nFAILURE: mcp.config.kubecostApiKey is set but mcp.config.oidc.authMode is not \"oidc\", \"both\", or \"api_key\". This is not secure: the MCP server holds a Kubecost API key while the MCP HTTP endpoint is not protected. Set mcp.config.oidc.authMode to oidc, both, or api_key, or clear the API key\n" }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
 {{- /*
   Compute a checksum based on the rendered content of specific ConfigMaps and Secrets.
 */ -}}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -629,15 +629,40 @@ protected with OIDC. When CI/CD skipSanityChecks is set, emit a warning instead.
 {{- $hasKeySecret := (((.Values.mcp).config).kubecostApiKey).existingSecret -}}
 {{- if and (.Values.mcp).enabled (or $hasKeyValue $hasKeySecret) }}
 {{- $authMode := include "kubecost.mcp.authMode" . -}}
-{{- if and (ne $authMode "oidc") (ne $authMode "both") (ne $authMode "api_key") }}
+{{- if and (ne $authMode "oidc") (ne $authMode "api_key") }}
 {{- if and .Values.global.platforms.cicd.enabled .Values.global.platforms.cicd.skipSanityChecks }}
 
-WARNING: MCP.CONFIG.KUBECOSTAPIKEY IS SET BUT MCP.CONFIG.AUTHMODE IS NOT "OIDC", "BOTH", OR "API_KEY". THIS IS
+WARNING: MCP.CONFIG.KUBECOSTAPIKEY IS SET BUT MCP.CONFIG.AUTHMODE IS NOT "OIDC" OR "API_KEY". THIS IS
 NOT SECURE: THE MCP SERVER HOLDS A KUBECOST API KEY WHILE THE MCP HTTP ENDPOINT IS NOT PROTECTED.
-SET MCP.CONFIG.AUTHMODE TO OIDC, BOTH, OR API_KEY, OR CLEAR THE API KEY.
+SET MCP.CONFIG.AUTHMODE TO OIDC OR API_KEY, OR CLEAR THE API KEY.
 SKIPSANITYCHECKS IS TRUE SO THIS CHECK DID NOT FAIL.
 {{- else }}
-{{- fail "\n\nFAILURE: mcp.config.kubecostApiKey is set but mcp.config.authMode is not \"oidc\", \"both\", or \"api_key\". This is not secure: the MCP server holds a Kubecost API key while the MCP HTTP endpoint is not protected. Set mcp.config.authMode to oidc, both, or api_key, or clear the API key\n" }}
+{{- fail "\n\nFAILURE: mcp.config.kubecostApiKey is set but mcp.config.authMode is not \"oidc\" or \"api_key\". This is not secure: the MCP server holds a Kubecost API key while the MCP HTTP endpoint is not protected. Set mcp.config.authMode to oidc or api_key, or clear the API key\n" }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Fail when authMode is "none" and either an MCP route (httpRoute or ingress) is
+enabled, or kubecostApiPort is 9008 (aggregator SSO bypass). In both cases the
+MCP endpoint would be unauthenticated while able to reach Kubecost without
+SSO. When CI/CD skipSanityChecks is set, emit a warning instead.
+*/}}
+{{- define "kubecost.mcp.openRouteCheck" -}}
+{{- if (.Values.mcp).enabled }}
+{{- $routeEnabled := or ((.Values.mcp).httpRoute).enabled ((.Values.mcp).ingress).enabled -}}
+{{- $apiPort := toString (default 9004 ((.Values.mcp).config).kubecostApiPort) -}}
+{{- $authMode := include "kubecost.mcp.authMode" . -}}
+{{- if and (or $routeEnabled (eq $apiPort "9008")) (eq $authMode "none") }}
+{{- if and .Values.global.platforms.cicd.enabled .Values.global.platforms.cicd.skipSanityChecks }}
+
+WARNING: MCP.CONFIG.AUTHMODE IS "NONE" WHILE MCP.HTTPROUTE/INGRESS IS ENABLED OR MCP.CONFIG.KUBECOSTAPIPORT IS 9008.
+THE MCP ENDPOINT WOULD BE UNPROTECTED WHILE ABLE TO BYPASS KUBECOST SSO. SET MCP.CONFIG.AUTHMODE TO AT LEAST "OPEN"
+TO ACKNOWLEDGE THIS, OR USE "OIDC" OR "API_KEY" TO ENFORCE AUTHENTICATION.
+SKIPSANITYCHECKS IS TRUE SO THIS CHECK DID NOT FAIL.
+{{- else }}
+{{- fail "\n\nFAILURE: mcp.config.authMode is \"none\" while mcp.httpRoute or mcp.ingress is enabled, or mcp.config.kubecostApiPort is 9008. The MCP endpoint would be unauthenticated while it can bypass Kubecost SSO on port 9008. Set mcp.config.authMode to at least \"open\" to acknowledge intentional unauthenticated exposure, or use \"oidc\" or \"api_key\" to enforce authentication.\n" }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/kubecost/templates/frontend/_helpers.tpl
+++ b/kubecost/templates/frontend/_helpers.tpl
@@ -90,31 +90,35 @@ Merge bufferConfig.directives with extraServerConfig lines, render nginx directi
 {{- end -}}
 
 {{/*
-Shared proxy directives for MCP upstream locations. Long read/send timeouts
-and buffering off are required for FastMCP streamable HTTP.
-When mcp.config.authMode is "none" the endpoint is unconfigured/unacknowledged;
-return a 503 informational response instead of proxying to the MCP backend.
+When mcp.config.authMode is "none" AND a Kubecost ingress/httpRoute is defined, block the endpoint
+until it is configured/acknowledged; otherwise, proxy to the MCP backend.
 When mcp.config.authMode is "open" the operator has explicitly acknowledged
 unauthenticated exposure — requests are proxied normally without auth enforcement.
+When mcp.config.authMode is "oidc/api_key" the endpoint is proxied with auth enforcement being handled by the MCP backend.
+This does not prevent an mcp.httpRoute or mcp.ingress from being enabled. Those checks exist in the sub-chart itself.
 */}}
 {{- define "kubecost.frontend.mcpProxyDirectives" -}}
-{{- if eq (include "kubecost.mcp.authMode" .) "none" -}}
-add_header Content-Type text/plain;
-return 503 "MCP endpoint is not configured. Set mcp.config.authMode to enable access.";
+{{- if and (eq (include "kubecost.mcp.authMode" .) "none") (or .Values.httpRoute.enabled .Values.ingress.enabled) -}}
+  add_header Content-Type text/plain;
+  return 424 "MCP endpoint is not configured. Set mcp.config.authMode to enable access.";
 {{- else -}}
-proxy_connect_timeout       300;
-proxy_send_timeout          3600;
-proxy_read_timeout          3600;
-proxy_pass http://mcpKubecost;
-proxy_redirect off;
-proxy_http_version 1.1;
-proxy_set_header Connection "";
-proxy_set_header Host $host;
-proxy_set_header X-Real-IP $remote_addr;
-proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-proxy_set_header X-Forwarded-Proto $scheme;
-proxy_buffering off;
-proxy_cache off;
-chunked_transfer_encoding on;
+{{/*
+Shared proxy directives for MCP upstream locations. Long read/send timeouts
+and buffering off are required for FastMCP streamable HTTP.
+*/}}
+  proxy_connect_timeout       300;
+  proxy_send_timeout          3600;
+  proxy_read_timeout          3600;
+  proxy_pass http://mcpKubecost;
+  proxy_redirect off;
+  proxy_http_version 1.1;
+  proxy_set_header Connection "";
+  proxy_set_header Host $host;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_buffering off;
+  proxy_cache off;
+  chunked_transfer_encoding on;
 {{- end -}}
 {{- end -}}

--- a/kubecost/templates/frontend/_helpers.tpl
+++ b/kubecost/templates/frontend/_helpers.tpl
@@ -89,19 +89,7 @@ Merge bufferConfig.directives with extraServerConfig lines, render nginx directi
   {{- trimSuffix "\n" $out -}}
 {{- end -}}
 
-{{/*
-When mcp.config.authMode is "none" AND a Kubecost ingress/httpRoute is defined, block the endpoint
-until it is configured/acknowledged; otherwise, proxy to the MCP backend.
-When mcp.config.authMode is "open" the operator has explicitly acknowledged
-unauthenticated exposure — requests are proxied normally without auth enforcement.
-When mcp.config.authMode is "oidc/api_key" the endpoint is proxied with auth enforcement being handled by the MCP backend.
-This does not prevent an mcp.httpRoute or mcp.ingress from being enabled. Those checks exist in the sub-chart itself.
-*/}}
 {{- define "kubecost.frontend.mcpProxyDirectives" -}}
-{{- if and (eq (include "kubecost.mcp.authMode" .) "none") (or .Values.httpRoute.enabled .Values.ingress.enabled) -}}
-  add_header Content-Type text/plain;
-  return 424 "MCP endpoint is not configured. Set mcp.config.authMode to enable access.";
-{{- else -}}
 {{/*
 Shared proxy directives for MCP upstream locations. Long read/send timeouts
 and buffering off are required for FastMCP streamable HTTP.
@@ -120,5 +108,4 @@ and buffering off are required for FastMCP streamable HTTP.
   proxy_buffering off;
   proxy_cache off;
   chunked_transfer_encoding on;
-{{- end -}}
 {{- end -}}

--- a/kubecost/templates/frontend/_helpers.tpl
+++ b/kubecost/templates/frontend/_helpers.tpl
@@ -88,3 +88,24 @@ Merge bufferConfig.directives with extraServerConfig lines, render nginx directi
   {{- end -}}
   {{- trimSuffix "\n" $out -}}
 {{- end -}}
+
+{{/*
+Shared proxy directives for MCP upstream locations. Long read/send timeouts
+and buffering off are required for FastMCP streamable HTTP.
+*/}}
+{{- define "kubecost.frontend.mcpProxyDirectives" -}}
+proxy_connect_timeout       300;
+proxy_send_timeout          3600;
+proxy_read_timeout          3600;
+proxy_pass http://mcpKubecost;
+proxy_redirect off;
+proxy_http_version 1.1;
+proxy_set_header Connection "";
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_buffering off;
+proxy_cache off;
+chunked_transfer_encoding on;
+{{- end -}}

--- a/kubecost/templates/frontend/_helpers.tpl
+++ b/kubecost/templates/frontend/_helpers.tpl
@@ -92,8 +92,10 @@ Merge bufferConfig.directives with extraServerConfig lines, render nginx directi
 {{/*
 Shared proxy directives for MCP upstream locations. Long read/send timeouts
 and buffering off are required for FastMCP streamable HTTP.
-When mcp.config.authMode is "none" the endpoint is unconfigured; return a
-503 informational response instead of proxying to the MCP backend.
+When mcp.config.authMode is "none" the endpoint is unconfigured/unacknowledged;
+return a 503 informational response instead of proxying to the MCP backend.
+When mcp.config.authMode is "open" the operator has explicitly acknowledged
+unauthenticated exposure — requests are proxied normally without auth enforcement.
 */}}
 {{- define "kubecost.frontend.mcpProxyDirectives" -}}
 {{- if eq (include "kubecost.mcp.authMode" .) "none" -}}

--- a/kubecost/templates/frontend/_helpers.tpl
+++ b/kubecost/templates/frontend/_helpers.tpl
@@ -92,8 +92,14 @@ Merge bufferConfig.directives with extraServerConfig lines, render nginx directi
 {{/*
 Shared proxy directives for MCP upstream locations. Long read/send timeouts
 and buffering off are required for FastMCP streamable HTTP.
+When mcp.config.authMode is "none" the endpoint is unconfigured; return a
+503 informational response instead of proxying to the MCP backend.
 */}}
 {{- define "kubecost.frontend.mcpProxyDirectives" -}}
+{{- if eq (include "kubecost.mcp.authMode" .) "none" -}}
+add_header Content-Type text/plain;
+return 503 "MCP endpoint is not configured. Set mcp.config.authMode to enable access.";
+{{- else -}}
 proxy_connect_timeout       300;
 proxy_send_timeout          3600;
 proxy_read_timeout          3600;
@@ -108,4 +114,5 @@ proxy_set_header X-Forwarded-Proto $scheme;
 proxy_buffering off;
 proxy_cache off;
 chunked_transfer_encoding on;
+{{- end -}}
 {{- end -}}

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -499,30 +499,84 @@ data:
         {{- end }}
 
         {{- if (.Values.mcp).enabled }}
+        {{- $mcpPrefix := include "kubecost.mcp.pathPrefix" . }}
+        {{- if $mcpPrefix }}
+        # MCP served under the {{ $mcpPrefix }} path prefix.
+        #
+        # mcp.config.oidc.baseUrl carries this prefix, so FastMCP advertises
+        # {{ $mcpPrefix }}/authorize, {{ $mcpPrefix }}/token, {{ $mcpPrefix }}/register and
+        # {{ $mcpPrefix }}{{ include "kubecost.mcp.redirectPath" . }} in its OAuth metadata. Nothing MCP-related
+        # claims a bare root path, so nothing can collide with Kubecost SSO
+        # (/auth, /login, /logout, /oidc/, /saml/) now or with a future
+        # Kubecost OAuth surface at the root well-known paths.
+        #
+        # nginx strips the prefix; the subchart serves the MCP endpoint at "/"
+        # (config.http.path) so both the endpoint and the stripped OAuth paths
+        # resolve. `=` and `^~` both outrank `location /` and its auth_request
+        # without relying on the regex-location precedence tier.
+        #
+        # Split into an exact match and a `{{ $mcpPrefix }}/` prefix so that sibling paths
+        # such as {{ $mcpPrefix }}-admin keep falling through to the frontend rather than
+        # being swallowed by a bare `{{ $mcpPrefix }}` prefix match.
+        location = {{ $mcpPrefix }} {
+            rewrite ^ / break;
+            {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
+        }
+
+        location ^~ {{ $mcpPrefix }}/ {
+            rewrite ^{{ $mcpPrefix }}(/.*)$ $1 break;
+            {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
+        }
+
+        # RFC 9728 protected-resource metadata. Clients derive this URL from the
+        # resource identifier, so it is requested at the host root and cannot be
+        # moved under the prefix — but it stays scoped to {{ $mcpPrefix }} by suffix.
+        # Served at the same path inside the container, so no rewrite.
+        location ^~ /.well-known/oauth-protected-resource{{ $mcpPrefix }} {
+            {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
+        }
+
+        # RFC 8414 authorization-server metadata for issuer {{ $mcpPrefix }}. FastMCP
+        # registers this route at the container root rather than the path-aware
+        # variant (fastmcp http.py builds routes via get_routes(), which skips
+        # the rewriting in get_well_known_routes()), so map it back.
+        # Clients that instead append /.well-known to the issuer are handled by
+        # the prefix-strip location above.
+        location ^~ /.well-known/oauth-authorization-server{{ $mcpPrefix }} {
+            rewrite ^ /.well-known/oauth-authorization-server break;
+            {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
+        }
+        {{- else }}
         # MCP streamable HTTP — FastMCP serves at /mcp on port {{ include "kubecost.mcp.servicePort" . }}
         location /mcp {
             {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
         }
+
+        {{- if eq (include "kubecost.mcp.authMode" .) "oidc" }}
+        # Root-level OAuth paths. Give mcp.config.oidc.baseUrl a path prefix
+        # (e.g. https://kubecost.example.com/mcp) to move all of these under
+        # that prefix instead of claiming them at the root of a shared host.
 
         # MCP OIDC callback. Must be a longer prefix than location /auth, or
         # /auth-mcp is treated as Kubecost auth_request (aggregator /isAuthenticated).
         location {{ include "kubecost.mcp.redirectPath" . }} {
             {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
         }
-
-        # MCP OAuth (OIDCProxy). location / runs auth_request /auth; these must
-        # reach FastMCP as JSON, not the Kubecost SSO HTML login page.
         location ~ ^/(register|authorize|token|consent)(/|$) {
             {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
         }
 
-        location ^~ /.well-known/oauth-protected-resource {
+        # OAuth discovery. Without these, both fall through to `location /`,
+        # whose auth_request returns the Kubecost SSO login page as HTML where
+        # the MCP client expects OAuth JSON.
+        location ^~ /.well-known/oauth-protected-resource/mcp {
             {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
         }
-
         location ^~ /.well-known/oauth-authorization-server {
             {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
         }
+        {{- end }}
+        {{- end }}
         {{- end }}
 
         location /model/productConfigs {
@@ -543,6 +597,10 @@ data:
                 "mcpAuthMode": "{{ include "kubecost.mcp.authMode" . }}",
                 "mcpRequireClientApiKey": "{{ include "kubecost.mcp.requireClientApiKey" . }}",
                 "mcpRedirectPath": "{{ include "kubecost.mcp.redirectPath" . }}",
+                "mcpPathPrefix": "{{ include "kubecost.mcp.pathPrefix" . }}",
+                "kubecostApiBaseUrl": "{{ include "kubecost.mcp.kubecostApiBaseUrl" . }}",
+                "kubecostApiPort": "{{ include "kubecost.mcp.kubecostApiPort" . }}",
+                "kubecostApiBasePath": "{{ include "kubecost.mcp.kubecostApiBasePath" . }}",
                 "chartVersion": "DEVELOP_BRANCH",
                 "tenMinuteDataRetention": "{{ (.Values.aggregator.retention10m) }}",
                 "hourlyDataRetention": "{{ (.Values.aggregator.retention1h) }}",

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -99,6 +99,20 @@ data:
     }
   {{- end }}
 
+  {{- if (.Values.mcp).enabled }}
+    upstream mcpKubecost {
+        {{- if .Values.frontend.useDefaultFqdn }}
+        server {{ include "kubecost.mcp.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ include "kubecost.mcp.servicePort" . }};
+        {{- else }}
+        {{- if (.Values.frontend.mcp).fqdn }}
+        server {{ .Values.frontend.mcp.fqdn }};
+        {{- else }}
+        server {{ include "kubecost.mcp.serviceName" . }}.{{ .Release.Namespace }}:{{ include "kubecost.mcp.servicePort" . }};
+        {{- end }}
+        {{- end }}
+    }
+  {{- end }}
+
     server {
         server_name _;
         root /var/www;
@@ -484,6 +498,33 @@ data:
         }
         {{- end }}
 
+        {{- if (.Values.mcp).enabled }}
+        # MCP streamable HTTP — FastMCP serves at /mcp on port {{ include "kubecost.mcp.servicePort" . }}
+        location /mcp {
+            {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
+        }
+
+        # MCP OIDC callback. Must be a longer prefix than location /auth, or
+        # /auth-mcp is treated as Kubecost auth_request (aggregator /isAuthenticated).
+        location {{ include "kubecost.mcp.redirectPath" . }} {
+            {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
+        }
+
+        # MCP OAuth (OIDCProxy). location / runs auth_request /auth; these must
+        # reach FastMCP as JSON, not the Kubecost SSO HTML login page.
+        location ~ ^/(register|authorize|token|consent)(/|$) {
+            {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
+        }
+
+        location ^~ /.well-known/oauth-protected-resource {
+            {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
+        }
+
+        location ^~ /.well-known/oauth-authorization-server {
+            {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
+        }
+        {{- end }}
+
         location /model/productConfigs {
             default_type 'application/json';
             return 200 '\n
@@ -498,6 +539,10 @@ data:
                 "clusterControllerEnabled": "{{ include "kubecost.clusterController.enabled" . }}",
                 "forecastingEnabled": "{{ include "kubecost.forecasting.enabled" . }}",
                 "turbonomicEnabled": "{{ include "kubecost.turbonomic.enabled" . }}",
+                "mcpEnabled": "{{ include "kubecost.mcp.enabled" . }}",
+                "mcpAuthMode": "{{ include "kubecost.mcp.authMode" . }}",
+                "mcpRequireClientApiKey": "{{ include "kubecost.mcp.requireClientApiKey" . }}",
+                "mcpRedirectPath": "{{ include "kubecost.mcp.redirectPath" . }}",
                 "chartVersion": "DEVELOP_BRANCH",
                 "tenMinuteDataRetention": "{{ (.Values.aggregator.retention10m) }}",
                 "hourlyDataRetention": "{{ (.Values.aggregator.retention1h) }}",

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -498,17 +498,29 @@ data:
         }
         {{- end }}
 
-        {{- if (.Values.mcp).enabled }}
+        {{- /* mcpProxy: Only proxy MCP if it is enabled and not using its own httproute or ingress */}}
+        {{- if and (.Values.mcp.enabled) (not (.Values.mcp.httpRoute.enabled)) (not (.Values.mcp.ingress.enabled)) }}
+        {{- $mcpAuthMode := include "kubecost.mcp.authMode" . }}
+        {{- /*
+        kubecost.mcp.pathPrefix is the path component of mcp.config.oidc.baseUrl,
+        and is empty unless authMode is "oidc". It decides which of the two
+        mutually exclusive modes below applies, because the subchart derives
+        config.http.path from the same value: the container serves the MCP
+        endpoint at "/" when there is a prefix to strip, at /mcp when there is not.
+
+        The modes must stay mutually exclusive. Rendering both repeats the
+        /.well-known locations, and nginx refuses to load a duplicated location.
+        */}}
         {{- $mcpPrefix := include "kubecost.mcp.pathPrefix" . }}
         {{- if $mcpPrefix }}
-        # MCP served under the {{ $mcpPrefix }} path prefix.
+        # mcpPrefixMode: MCP served under the {{ $mcpPrefix }} path prefix of the Kubecost host.
         #
         # mcp.config.oidc.baseUrl carries this prefix, so FastMCP advertises
         # {{ $mcpPrefix }}/authorize, {{ $mcpPrefix }}/token, {{ $mcpPrefix }}/register and
         # {{ $mcpPrefix }}{{ include "kubecost.mcp.redirectPath" . }} in its OAuth metadata. Nothing MCP-related
-        # claims a bare root path, so nothing can collide with Kubecost SSO
-        # (/auth, /login, /logout, /oidc/, /saml/) now or with a future
-        # Kubecost OAuth surface at the root well-known paths.
+        # claims a bare root path in this mode, so nothing can collide with
+        # Kubecost SSO (/auth, /login, /logout, /oidc/, /saml/) now or with a
+        # future Kubecost OAuth surface at the root well-known paths.
         #
         # nginx strips the prefix; the subchart serves the MCP endpoint at "/"
         # (config.http.path) so both the endpoint and the stripped OAuth paths
@@ -547,18 +559,21 @@ data:
             {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
         }
         {{- else }}
+        # mcpHostRootMode: no path prefix, so the subchart serves the MCP
+        # endpoint at /mcp (config.http.path) and every OAuth route at the
+        # container root. Paths pass through unrewritten.
         # MCP streamable HTTP — FastMCP serves at /mcp on port {{ include "kubecost.mcp.servicePort" . }}
         location /mcp {
             {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
         }
-
-        {{- if eq (include "kubecost.mcp.authMode" .) "oidc" }}
+        {{- /* mcpOidc: when mcp is using oidc auth: create oidc paths that do not conflict with kubecost oidc */}}
+        {{- if eq $mcpAuthMode "oidc" }}
         # Root-level OAuth paths. Give mcp.config.oidc.baseUrl a path prefix
         # (e.g. https://kubecost.example.com/mcp) to move all of these under
         # that prefix instead of claiming them at the root of a shared host.
 
         # MCP OIDC callback. Must be a longer prefix than location /auth, or
-        # /auth-mcp is treated as Kubecost auth_request (aggregator /isAuthenticated).
+        # {{ include "kubecost.mcp.redirectPath" . }} is treated as Kubecost auth_request (aggregator /isAuthenticated).
         location {{ include "kubecost.mcp.redirectPath" . }} {
             {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
         }

--- a/kubecost/values-eks-cost-monitoring.yaml
+++ b/kubecost/values-eks-cost-monitoring.yaml
@@ -24,3 +24,7 @@ clusterController:
 finopsagent:
   image:
     repository: kubecost/agent
+
+mcp:
+  image:
+    repository: kubecost/mcp

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -670,10 +670,38 @@ mcp:
     kubecostApiPort: 9004
     kubecostApiBasePath: /
     ## Authentication for the MCP HTTP endpoint. One of: none, open, oidc, api_key.
-    ## To require both OIDC and X-API-KEY, set authMode: oidc and mcp.config.requireClientApiKey: true.
     ## The default of "none" leaves the endpoint unauthenticated inside the cluster;
     ## See https://github.com/kubecost/mcp-kubecost/tree/main/docs/auth for more details.
     authMode: none
+    oidc:
+      # mcp.config.oidc.issuerUrl is the provider's .well-known/openid-configuration URL.
+      # Example: https://{domain}/.well-known/openid-configuration
+      issuerUrl: ""
+      # mcp.config.oidc.baseUrl is the public URL of this MCP server (used for OAuth redirect callback).
+      #
+      # When the MCP server shares the Kubecost frontend hostname, give this a
+      # path prefix -- https://kubecost.example.com/mcp -- so FastMCP advertises
+      # every OAuth endpoint under that prefix (/mcp/authorize, /mcp/token,
+      # /mcp/register, /mcp/auth-mcp) instead of claiming those names at the
+      # root of a host it shares with Kubecost SSO. The frontend nginx strips
+      # the prefix, and the subchart then serves the MCP endpoint at "/".
+      # Register the redirect URI at the IdP with the prefix included.
+      #
+      # Leave the path off (https://mcp.example.com) only when the MCP server
+      # has its own hostname, where there is nothing to collide with.
+      baseUrl: ""
+      # mcp.config.oidc.redirectPath is the FastMCP OAuth callback path
+      # The default is /auth-mcp which is to avoid conflict with the Kubecost OIDC callback for the main UI
+      # With a path-prefixed baseUrl this is served under the prefix, so it no
+      # longer has to out-length the Kubecost /auth location.
+      redirectPath: "/auth-mcp"
+      # mcp.config.oidc.clientId is the OIDC client ID. Prefer existingSecret for production.
+      clientId: ""
+      # mcp.config.oidc.clientSecret is the OIDC client secret. Prefer existingSecret for production.
+      clientSecret: ""
+      # mcp.config.oidc.existingSecret references a pre-created Secret containing OIDC credentials.
+      # Required keys: OIDC_CLIENT_ID, OIDC_CLIENT_SECRET. Preferred over clientId/clientSecret.
+      existingSecret: ""
   ## The MCP server is reachable in-cluster at <release>-mcp:3030. Enable
   ## httpRoute (Gateway API) or ingress to expose it outside the cluster.
   httpRoute:

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -669,22 +669,21 @@ mcp:
     kubecostApiBasePath: /model
     ## Authentication for the MCP HTTP endpoint. One of: none, oidc, api_key, both.
     ## The default of "none" leaves the endpoint unauthenticated inside the cluster;
-    ## set an authMode before exposing it through ingress.hosts or httpRoute.
-    # oidc:
-    #   authMode: none
+    ## set mcp.config.authMode before exposing it through ingress.hosts or httpRoute.
+    authMode: none
   ## The MCP server is reachable in-cluster at <release>-mcp:3030. Enable
   ## httpRoute (Gateway API) or ingress to expose it outside the cluster.
-  # httpRoute:
-  #   enabled: false
-  # ingress:
-  #   enabled: false
-  # resources:
-  #   requests:
-  #     cpu: 250m
-  #     memory: 1Gi
-  #   limits:
-  #     cpu: 1000m
-  #     memory: 1Gi
+  httpRoute:
+    enabled: false
+  ingress:
+    enabled: false
+  resources:
+    requests:
+      cpu: 250m
+      memory: 1Gi
+    limits:
+      cpu: 1000m
+      memory: 1Gi
 
 ## Installs Kubecost/OpenCost plugins
 ## Ref: https://opencost.io/docs/integrations/plugins/

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -662,14 +662,17 @@ finopsagent:
 ##
 mcp:
   enabled: true
-  ## The MCP server reads cost data through the Kubecost frontend Service
-  ## (`<release>-frontend:9090`). This value is tpl-evaluated by the subchart.
+  ## The MCP server reads cost data through the Kubecost aggregator Service.
+  ## If Kubecost is deployed with SAML or OIDC authentication,
+  ## set mcp.config.kubecostApiPort to 9008 instead of 9004 to bypass authentication.
   config:
-    kubecostBaseUrl: "http://{{ .Release.Name }}-frontend:9090"
-    kubecostApiBasePath: /model
-    ## Authentication for the MCP HTTP endpoint. One of: none, oidc, api_key, both.
+    kubecostApiBaseUrl: "http://{{ .Release.Name }}-aggregator"
+    kubecostApiPort: 9004
+    kubecostApiBasePath: /
+    ## Authentication for the MCP HTTP endpoint. One of: none, open, oidc, api_key.
+    ## To require both OIDC and X-API-KEY, set authMode: oidc and mcp.config.requireClientApiKey: true.
     ## The default of "none" leaves the endpoint unauthenticated inside the cluster;
-    ## set mcp.config.authMode before exposing it through ingress.hosts or httpRoute.
+    ## See https://github.com/kubecost/mcp-kubecost/tree/main/docs/auth for more details.
     authMode: none
   ## The MCP server is reachable in-cluster at <release>-mcp:3030. Enable
   ## httpRoute (Gateway API) or ingress to expose it outside the cluster.

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -544,6 +544,8 @@ frontend:
     fqdn: ""  # Example: kubecost-cloud-cost.kubecost.svc.cluster.local:9005
   clusterController:
     fqdn: ""  # Example: cluster-controller.kubecost.svc.cluster.local:9731
+  mcp:
+    fqdn: ""  # Example: kubecost-mcp.kubecost.svc.cluster.local:3030
 
 ## Kubecost Local Store
 ## When no federated storage bucket is configured, localStore provides local storage via a

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -654,6 +654,36 @@ finopsagent:
       spotLabel: ""
       spotLabelValue: ""
 
+## The FinOps MCP server for Kubecost analytics. Below are a subset of values from
+## the mcp-kubecost subchart that are most commonly changed.
+## Ref: https://github.com/kubecost/mcp-kubecost/blob/main/charts/mcp-kubecost/values.yaml
+##
+mcp:
+  enabled: true
+  ## The MCP server reads cost data through the Kubecost frontend Service
+  ## (`<release>-frontend:9090`). This value is tpl-evaluated by the subchart.
+  config:
+    kubecostBaseUrl: "http://{{ .Release.Name }}-frontend:9090"
+    kubecostApiBasePath: /model
+    ## Authentication for the MCP HTTP endpoint. One of: none, oidc, api_key, both.
+    ## The default of "none" leaves the endpoint unauthenticated inside the cluster;
+    ## set an authMode before exposing it through ingress.hosts or httpRoute.
+    # oidc:
+    #   authMode: none
+  ## The MCP server is reachable in-cluster at <release>-mcp:3030. Enable
+  ## httpRoute (Gateway API) or ingress to expose it outside the cluster.
+  # httpRoute:
+  #   enabled: false
+  # ingress:
+  #   enabled: false
+  # resources:
+  #   requests:
+  #     cpu: 250m
+  #     memory: 1Gi
+  #   limits:
+  #     cpu: 1000m
+  #     memory: 1Gi
+
 ## Installs Kubecost/OpenCost plugins
 ## Ref: https://opencost.io/docs/integrations/plugins/
 ##


### PR DESCRIPTION
## Summary
- Adds the [mcp-kubecost](https://github.com/kubecost/mcp-kubecost) Helm chart as a subchart (`alias: mcp`, pinned to `0.6.2`) so the FinOps MCP server deploys with Kubecost.
- The MCP server is **enabled by default**. Existing installs will start running it on upgrade unless they set `mcp.enabled=false`. It talks to the in-cluster frontend Service via a tpl `kubecostBaseUrl` (`http://{{ .Release.Name }}-frontend:9090`).
- Adds a CI workflow that builds dependencies, lints/templates the chart, asserts subchart wiring (frontend URL, `global:` inheritance, OpenShift/CI-CD cases), and kubeconform-validates the rendered manifests.

## Test plan
- [x] `helm dependency build ./kubecost` succeeds and `Chart.lock` stays in sync with `Chart.yaml` (`mcp-kubecost` 0.6.2)
- [x] Default render includes MCP resources (`Deployment`/`Service`/`ConfigMap` named `<release>-mcp`):
  ```sh
  rm -rf ./kubecost/charts
  helm repo add mcp-kubecost https://kubecost.github.io/mcp-kubecost
  helm repo add finops-agent https://kubecost.github.io/finops-agent-chart/
  helm repo update
  helm dependency build ./kubecost
  helm template kubecost ./kubecost --skip-schema-validation | grep -E 'kind: (Deployment|Service|ConfigMap)|name: kubecost-mcp'
  ```
- [x] Opt-out works: `helm template kubecost ./kubecost --set mcp.enabled=false` does **not** render `charts/mcp/` resources
- [ ] MCP `KUBECOST_BASE_URL` matches the rendered frontend Service (`http://<release>-frontend:9090`) for both `kubecost` and an alternate release name
- [ ] `.github/scripts/validate_mcp_subchart.sh kubecost` passes locally
- [ ] GitHub Actions `Validate mcp-kubecost subchart` is green on this PR

## Notes for reviewers
- `Chart.yaml` still comments that the subchart is “Disabled by default”; `values.yaml` and the validator now default `mcp.enabled` to `true`. Worth aligning that comment.
- The MCP HTTP endpoint defaults to unauthenticated in-cluster (`authMode: none`). Auth should be configured before exposing via ingress / HTTPRoute.
- `helm template` uses `--skip-schema-validation` because the subchart schema uses `additionalProperties: false` and does not declare Helm’s injected `enabled` field.