### PR TITLE
update cluster controller image to v0.16.39

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1393,7 +1393,7 @@ clusterController:
   image:
     registry: ""  # Default is "icr.io"
     repository: kubecost/cluster-controller
-    tag: v0.16.38
+    tag: v0.16.39
   imagePullPolicy: IfNotPresent
   logLevel: info
   extraEnv: []


### PR DESCRIPTION
## Release Notes Headline
Prevent namespace turndown from deleting `kube-system`, `kubecost`, and `ibm-finops-agent` namespaces
<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers
Namespace turndown will no longer turndown the `kube-system`, `kubecost`, and `ibm-finops-agent` namespaces
<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets
N/A
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
N/A
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Unit tested in cluster-controller repo and tested image on live environment
<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates
N/A
<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
