### PR TITLE
CLDYCON-7823 - Add persistentVolumeClaimRetentionPolicy

### DIFF
--- a/kubecost/templates/aggregator/aggregator-statefulset.yaml
+++ b/kubecost/templates/aggregator/aggregator-statefulset.yaml
@@ -20,6 +20,11 @@ metadata:
 spec:
   replicas: {{ .Values.aggregator.replicas }}
   serviceName: {{ template "kubecost.aggregator.serviceName" . }}
+  {{- with .Values.aggregator.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: {{ .whenDeleted | default "Retain" }}
+    whenScaled: {{ .whenScaled | default "Retain" }}
+  {{- end }}
   selector:
     matchLabels:
     {{- include "kubecost.aggregator.selectorLabels" . | nindent 6 }}

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1067,11 +1067,7 @@ aggregator:
   replicas: 1
 
   ## Controls what happens to the Aggregator's PVCs when its StatefulSet is
-  ## deleted or scaled down. Defaults to Retain/Retain (the Kubernetes default —
-  ## volumes survive, safe for all users). Hosted deployments may set
-  ## whenDeleted: Delete so per-tenant volumes are reclaimed on deprovision,
-  ## preventing orphaned EBS volumes (CLDYCON-7823). whenScaled should stay
-  ## Retain — scaling down must never destroy data.
+  ## deleted or scaled down.
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Retain

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1066,6 +1066,16 @@ aggregator:
   # Replicas sets the number of Aggregator replicas.
   replicas: 1
 
+  ## Controls what happens to the Aggregator's PVCs when its StatefulSet is
+  ## deleted or scaled down. Defaults to Retain/Retain (the Kubernetes default —
+  ## volumes survive, safe for all users). Hosted deployments may set
+  ## whenDeleted: Delete so per-tenant volumes are reclaimed on deprovision,
+  ## preventing orphaned EBS volumes (CLDYCON-7823). whenScaled should stay
+  ## Retain — scaling down must never destroy data.
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain
+
   ## Sets the pod termination grace period for the Aggregator StatefulSet. Must
   ## exceed shutdown_wait_unfinished (120s in kc-embedded-ch-config.xml) plus
   ## app drain time.


### PR DESCRIPTION
## Release Notes Headline
* N/A.

## Commentary for Reviewers
* Adds `persistentVolumeClaimRetentionPolicy` to the aggregator statefulset, which determines what happens to the attached PVCs when the aggregator is deleted or scaled down.

## Links to Issues or Tickets
* [CLDYCON-7823](https://apptio.atlassian.net/browse/CLDYCON-7823).

## User Impact and Risks
* No impact to users, only affects deleted tenants.

## Testing
* N/A.

## Documentation Updates
* N/A>

[CLDYCON-7823]: https://apptio.atlassian.net/browse/CLDYCON-7823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ