### PR TITLE
Update Network Costs Version to v0.19.2

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -799,12 +799,12 @@ networkCosts:
   ## If not set, the image will be pulled from the registry and repository specified in the image block.
   ## If set, the fullImageName will be used to pull the image.
   ## Example:
-  ## fullImageName: icr.io/kubecost/network-costs:v0.19.0
+  ## fullImageName: icr.io/kubecost/network-costs:v0.19.2
   fullImageName: ""
   image:
     registry: ""  # Default is "icr.io"
     repository: kubecost/network-costs
-    tag: v0.19.1
+    tag: v0.19.2
   imagePullPolicy: IfNotPresent
 
   updateStrategy:
@@ -948,7 +948,7 @@ networkCosts:
   ##       access_key: my-access-key
   ##       secret_key: my-secret-key
   ##       aws_sdk_auth: false
-  ##     refresh-interval: "10m"
+  ##     refresh-interval: "5m"
   natGatewayConfig: {}
 
   ## Network costs is a daemonset and may need to be scheduled on nodes with specific taints.


### PR DESCRIPTION
## Release Notes Headline
* Updated Network Costs version to `v0.19.2`, which adds a Traffic Deferral Queue for delayed NAT Gateway bound classification resolution. 

### Traffic Deferral

Conntrack is read every few seconds, but flow logs describing that same traffic are published by AWS several minutes later and only re-processed on `refresh-interval`. A NAT bound connection is therefore visible long before there is any way to know it is NAT bound. Without deferral, the connection's first samples are reported as `nat_gateway="false"` and its later samples as `nat_gateway="true"` — one pod's bytes split across two series — and short lived connections are never tagged at all.

Deferral holds traffic that looks NAT bound out of the metric stream. Once flow logs can answer for it, the held samples are replayed with the correct label, so the whole connection lands on a single series. Only traffic carrying a source-address rewrite is held along with node sourced traffic for NodeIPs. Most of the traffic flowing through the pipeline is left unchanged. If the NAT Gateway is unreachable from the current Node or if it is disabled completely, none of the traffic is held up. 

