### PR TITLE
Simplify the MCP Helm configuration and frontend proxy logic

### DIFF
--- a/.github/scripts/validate_mcp_subchart.sh
+++ b/.github/scripts/validate_mcp_subchart.sh
@@ -1,26 +1,20 @@
 #!/usr/bin/env bash
 #
-# Validates the mcp-kubecost subchart integration in the kubecost chart.
+# Validates the mcp-kubecost dependency declaration in the kubecost chart.
 #
-# Checks performed:
-#   1. Chart.yaml declares mcp-kubecost with a condition, and Chart.lock agrees.
-#   2. The subchart renders nothing by default (opt-in only).
-#   3. helm lint passes with the subchart enabled.
-#   4. The full chart renders and produces the expected mcp-kubecost resources.
-#   5. Parent `global:` values are inherited by the subchart (conformance check).
-#   6. The subchart's Kubecost API base URL points at the rendered frontend Service.
+# Chart.yaml, Chart.lock, and the vendored tarball are what a shell script is
+# actually needed for. Everything about the rendered output — cross-chart wiring,
+# the frontend nginx proxy, global: conformance, and the exposure guards — is
+# covered by the helm-unittest suites in kubecost/tests/, which this script runs.
 #
 # Usage (from the repository root):
 #   .github/scripts/validate_mcp_subchart.sh [chart-dir]
 #
-# Requires: helm >= 3.8, yq >= 4.
+# Requires: helm >= 3.8 with the unittest plugin, and yq >= 4.
 set -euo pipefail
 
 CHART_DIR="${1:-kubecost}"
-RELEASE_NAME="kubecost"
 SUBCHART_NAME="mcp-kubecost"
-RENDER_DIR="$(mktemp -d)"
-trap 'rm -rf "$RENDER_DIR"' EXIT
 
 failures=0
 
@@ -42,55 +36,9 @@ assert_eq() {
   fi
 }
 
-# assert_contains <description> <file> <fixed-string>
-assert_contains() {
-  local desc="$1" file="$2" needle="$3"
-  if grep -qF -- "$needle" "$file"; then
-    pass "$desc"
-  else
-    fail "$desc (missing '${needle}')"
-  fi
-}
-
-# assert_absent <description> <file> <fixed-string>
-assert_absent() {
-  local desc="$1" file="$2" needle="$3"
-  if grep -qF -- "$needle" "$file"; then
-    fail "$desc (unexpectedly found '${needle}')"
-  else
-    pass "$desc"
-  fi
-}
-
-# extract_nginx <render-file> <out-file>
-# Pulls the frontend nginx.conf out of a helm template render.
-extract_nginx() {
-  yq -r \
-    'select(.kind == "ConfigMap" and (.metadata.name | test("^nginx-conf-"))) | .data["nginx.conf"]' \
-    "$1" > "$2"
-}
-
-# assert_helm_fails <description> <stderr-needle> [extra helm --set args...]
-# Renders with the subchart enabled; expects helm template to fail with needle in stderr.
-assert_helm_fails() {
-  local desc="$1" needle="$2"
-  shift 2
-  local stderr_file="${RENDER_DIR}/helm-fail.err"
-  set +e
-  helm template "$RELEASE_NAME" "$CHART_DIR" \
-    "${skip_schema[@]}" \
-    --set "${values_key}.enabled=true" \
-    "$@" \
-    > /dev/null 2>"$stderr_file"
-  local _exit_code=$?
-  set -e
-  if [[ "$_exit_code" -eq 0 ]]; then
-    fail "helm template should have failed ${desc}"
-  elif grep -qF -- "$needle" "$stderr_file"; then
-    pass "helm template fails ${desc} (exit code ${_exit_code})"
-  else
-    fail "helm template failed ${desc} but stderr did not contain '${needle}'"
-  fi
+# dep_field <field> — read one field of the mcp-kubecost dependency from a chart file.
+dep_field() {
+  yq -r ".dependencies[] | select(.name == \"${SUBCHART_NAME}\") | .$1 // \"\"" "$2"
 }
 
 # ---------------------------------------------------------------------------
@@ -99,19 +47,7 @@ group "Chart metadata"
 chart_yaml="${CHART_DIR}/Chart.yaml"
 chart_lock="${CHART_DIR}/Chart.lock"
 
-dep_version="$(yq -r \
-  ".dependencies[] | select(.name == \"${SUBCHART_NAME}\") | .version // \"\"" \
-  "$chart_yaml")"
-dep_repository="$(yq -r \
-  ".dependencies[] | select(.name == \"${SUBCHART_NAME}\") | .repository // \"\"" \
-  "$chart_yaml")"
-dep_condition="$(yq -r \
-  ".dependencies[] | select(.name == \"${SUBCHART_NAME}\") | .condition // \"\"" \
-  "$chart_yaml")"
-dep_alias="$(yq -r \
-  ".dependencies[] | select(.name == \"${SUBCHART_NAME}\") | .alias // \"\"" \
-  "$chart_yaml")"
-
+dep_version="$(dep_field version "$chart_yaml")"
 if [ -z "$dep_version" ]; then
   fail "${chart_yaml} declares a ${SUBCHART_NAME} dependency"
   exit 1
@@ -119,28 +55,22 @@ fi
 pass "${chart_yaml} declares ${SUBCHART_NAME} ${dep_version}"
 
 # The values key is the alias when set, otherwise the chart name.
-values_key="${dep_alias:-$SUBCHART_NAME}"
+values_key="$(dep_field alias "$chart_yaml")"
+values_key="${values_key:-$SUBCHART_NAME}"
 
 assert_eq "dependency repository is the mcp-kubecost Helm repo" \
-  "https://kubecost.github.io/mcp-kubecost" "$dep_repository"
+  "https://kubecost.github.io/mcp-kubecost" "$(dep_field repository "$chart_yaml")"
 assert_eq "dependency condition gates the subchart" \
-  "${values_key}.enabled" "$dep_condition"
-
-if [ "$dep_version" = "*" ] || [ "${dep_version#\^}" != "$dep_version" ] \
-  || [ "${dep_version#\~}" != "$dep_version" ]; then
-  fail "dependency version must be pinned for reproducible builds, got '${dep_version}'"
-else
-  pass "dependency version is pinned"
-fi
-
-lock_version="$(yq -r \
-  ".dependencies[] | select(.name == \"${SUBCHART_NAME}\") | .version // \"\"" \
-  "$chart_lock")"
+  "${values_key}.enabled" "$(dep_field condition "$chart_yaml")"
 assert_eq "${chart_lock} pins the same version as ${chart_yaml}" \
-  "${dep_version#v}" "${lock_version#v}"
+  "${dep_version#v}" "$(dep_field version "$chart_lock" | sed 's/^v//')"
+assert_eq "values.yaml defaults ${values_key}.enabled to true" \
+  "true" "$(yq -r ".[\"${values_key}\"].enabled" "${CHART_DIR}/values.yaml")"
 
-default_enabled="$(yq -r ".[\"${values_key}\"].enabled" "${CHART_DIR}/values.yaml")"
-assert_eq "values.yaml defaults ${values_key}.enabled to true" "true" "$default_enabled"
+case "$dep_version" in
+  \*|^*|~*) fail "dependency version must be pinned for reproducible builds, got '${dep_version}'" ;;
+  *) pass "dependency version is pinned" ;;
+esac
 
 # ---------------------------------------------------------------------------
 group "Dependency resolution (validates Chart.lock is in sync)"
@@ -155,667 +85,38 @@ else
   pass "helm dependency build succeeded (Chart.lock in sync with Chart.yaml)"
 fi
 
-if [ ! -f "${CHART_DIR}/charts/${SUBCHART_NAME}-${dep_version#v}.tgz" ]; then
-  fail "expected ${CHART_DIR}/charts/${SUBCHART_NAME}-${dep_version#v}.tgz to be present"
-else
+if [ -f "${CHART_DIR}/charts/${SUBCHART_NAME}-${dep_version#v}.tgz" ]; then
   pass "subchart tarball ${SUBCHART_NAME}-${dep_version#v}.tgz present"
+else
+  fail "expected ${CHART_DIR}/charts/${SUBCHART_NAME}-${dep_version#v}.tgz to be present"
 fi
 
-# mcp-kubecost 0.6.0's values.schema.json uses additionalProperties: false and
-# does not declare `enabled`, which Helm injects from Chart.yaml `condition`.
-# Skip JSON-schema validation whenever the subchart is enabled.
-skip_schema=(--skip-schema-validation)
-
 # ---------------------------------------------------------------------------
-group "helm lint"
+group "helm lint and render"
 
+# No --skip-schema-validation: the subchart's values.schema.json is the strongest
+# guard against the parent and subchart drifting apart, so CI must enforce it.
 helm lint "$CHART_DIR"
-pass "helm lint (defaults)"
+pass "helm lint"
 
-helm lint "$CHART_DIR" "${skip_schema[@]}" --set "${values_key}.enabled=true"
-pass "helm lint (--set ${values_key}.enabled=true)"
+helm template mcp-schema-check "$CHART_DIR" > /dev/null
+pass "helm template (defaults, schema enforced)"
 
 # ---------------------------------------------------------------------------
-group "Subchart is enabled by default"
+group "Template behaviour (helm unittest)"
 
-helm template "$RELEASE_NAME" "$CHART_DIR" "${skip_schema[@]}" > "${RENDER_DIR}/default.yaml"
-pass "helm template (defaults) rendered without errors"
-
-# Only look at rendered resource sources, since the diagnostics ConfigMap
-# embeds the full values tree and always mentions the subchart key.
-default_sources="$(grep '^# Source:' "${RENDER_DIR}/default.yaml" || true)"
-# Helm uses the alias (when set) as the on-disk chart directory in # Source: lines.
-if printf '%s\n' "$default_sources" | grep -q "charts/${values_key}/"; then
-  pass "subchart resources rendered with ${values_key}.enabled=true (default)"
+if helm unittest "$CHART_DIR"; then
+  pass "helm unittest suites"
 else
-  fail "subchart rendered no resources despite ${values_key}.enabled=true (default)"
+  fail "helm unittest suites"
 fi
-
-# ---------------------------------------------------------------------------
-group "Subchart renders expected resources"
-
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  > "${RENDER_DIR}/enabled.yaml"
-pass "helm template (${values_key}.enabled=true) rendered without errors"
-
-expected_fullname="${RELEASE_NAME}-${values_key}"
-
-for kind in Deployment Service ConfigMap; do
-  found="$(yq -r \
-    "select(.kind == \"${kind}\") | .metadata.name | select(. == \"${expected_fullname}\" or . == \"${expected_fullname}-config\")" \
-    "${RENDER_DIR}/enabled.yaml" | head -1)"
-  if [ -n "$found" ]; then
-    pass "rendered ${kind}/${found}"
-  else
-    fail "expected a ${kind} named ${expected_fullname} (or ${expected_fullname}-config)"
-  fi
-done
-
-# The Deployment must be schedulable and reference the published image.
-mcp_image="$(yq -r \
-  "select(.kind == \"Deployment\" and .metadata.name == \"${expected_fullname}\") | .spec.template.spec.containers[0].image" \
-  "${RENDER_DIR}/enabled.yaml")"
-assert_eq "subchart Deployment uses the pinned appVersion image" \
-  "icr.io/kubecost/mcp-kubecost:${dep_version#v}" "$mcp_image"
-
-svc_port="$(yq -r \
-  "select(.kind == \"Service\" and .metadata.name == \"${expected_fullname}\") | .spec.ports[0].port" \
-  "${RENDER_DIR}/enabled.yaml")"
-assert_eq "subchart Service exposes the MCP port" "3030" "$svc_port"
-
-# ---------------------------------------------------------------------------
-group "Cross-chart wiring"
-
-# KUBECOST_BASE_URL is assembled from kubecostApiBaseUrl (tpl-evaluated) and
-# kubecostApiPort. Assert that the rendered ConfigMap reflects the expected
-# aggregator service name (derived from the release name) and the default port.
-base_url="$(yq -r \
-  "select(.kind == \"ConfigMap\" and .metadata.name == \"${expected_fullname}-config\") | .data.KUBECOST_BASE_URL" \
-  "${RENDER_DIR}/enabled.yaml")"
-assert_eq "subchart KUBECOST_BASE_URL targets the in-cluster Kubecost aggregator" \
-  "http://${RELEASE_NAME}-aggregator:9004" "$base_url"
-
-# kubecostApiBaseUrl is a tpl string, so a different release name must produce
-# a matching aggregator URL in KUBECOST_BASE_URL.
-alt_release="cost-analyzer"
-helm template "$alt_release" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  > "${RENDER_DIR}/alt-release.yaml"
-pass "helm template (release ${alt_release}) rendered without errors"
-
-alt_fullname="${alt_release}-${values_key}"
-alt_base_url="$(yq -r \
-  "select(.kind == \"ConfigMap\" and .metadata.name == \"${alt_fullname}-config\") | .data.KUBECOST_BASE_URL" \
-  "${RENDER_DIR}/alt-release.yaml")"
-assert_eq "subchart KUBECOST_BASE_URL follows a non-default release name" \
-  "http://${alt_release}-aggregator:9004" "$alt_base_url"
-
-# ---------------------------------------------------------------------------
-group "Frontend nginx MCP proxy"
-
-# The frontend ConfigMap must proxy MCP HTTP to the subchart Service when
-# enabled, and report MCP settings from /model/productConfigs. The OIDC
-# callback location is only rendered when authMode is oidc.
-extract_nginx "${RENDER_DIR}/enabled.yaml" "${RENDER_DIR}/nginx-enabled.conf"
-
-assert_contains "frontend nginx defines the mcpKubecost upstream when enabled" \
-  "${RENDER_DIR}/nginx-enabled.conf" "upstream mcpKubecost"
-assert_contains "frontend nginx targets the subchart Service" \
-  "${RENDER_DIR}/nginx-enabled.conf" "server ${expected_fullname}."
-assert_contains "frontend nginx proxies /mcp" \
-  "${RENDER_DIR}/nginx-enabled.conf" "location ^~ /mcp"
-assert_absent "frontend nginx omits the MCP OAuth locations when authMode is not oidc" \
-  "${RENDER_DIR}/nginx-enabled.conf" "location ^~ /oauth/mcp/"
-assert_absent "frontend nginx no longer claims root-level OAuth paths" \
-  "${RENDER_DIR}/nginx-enabled.conf" "^/(register|authorize|token|consent)"
-assert_contains "productConfigs reports mcpEnabled=true" \
-  "${RENDER_DIR}/nginx-enabled.conf" '"mcpEnabled": "true"'
-assert_contains "productConfigs reports default mcpAuthMode" \
-  "${RENDER_DIR}/nginx-enabled.conf" '"mcpAuthMode": "none"'
-assert_absent "productConfigs no longer reports mcpRedirectPath" \
-  "${RENDER_DIR}/nginx-enabled.conf" '"mcpRedirectPath"'
-assert_absent "productConfigs no longer reports mcpPathPrefix" \
-  "${RENDER_DIR}/nginx-enabled.conf" '"mcpPathPrefix"'
-assert_contains "productConfigs reports tpl-evaluated kubecostApiBaseUrl" \
-  "${RENDER_DIR}/nginx-enabled.conf" "\"kubecostApiBaseUrl\": \"http://${RELEASE_NAME}-aggregator\""
-assert_contains "productConfigs reports default kubecostApiPort" \
-  "${RENDER_DIR}/nginx-enabled.conf" '"kubecostApiPort": "9004"'
-assert_contains "productConfigs reports default kubecostApiBasePath" \
-  "${RENDER_DIR}/nginx-enabled.conf" '"kubecostApiBasePath": "/"'
-
-# authMode=api_key always requires a client API key. An explicit false value is
-# retained for backwards-compatible values files but must not weaken the mode.
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set "${values_key}.config.authMode=api_key" \
-  --set "${values_key}.config.requireClientApiKey=false" \
-  > "${RENDER_DIR}/api-key.yaml"
-pass "helm template (authMode=api_key, requireClientApiKey=false) rendered without errors"
-
-api_key_required="$(yq -r \
-  "select(.kind == \"ConfigMap\" and .metadata.name == \"${expected_fullname}-config\") | .data.REQUIRE_CLIENT_API_KEY" \
-  "${RENDER_DIR}/api-key.yaml")"
-assert_eq "subchart forces REQUIRE_CLIENT_API_KEY=true when authMode=api_key" \
-  "true" "$api_key_required"
-
-extract_nginx "${RENDER_DIR}/api-key.yaml" "${RENDER_DIR}/nginx-api-key.conf"
-assert_contains "productConfigs forces mcpRequireClientApiKey=true when authMode=api_key" \
-  "${RENDER_DIR}/nginx-api-key.conf" '"mcpRequireClientApiKey": "true"'
-
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=false" \
-  > "${RENDER_DIR}/disabled.yaml"
-pass "helm template (${values_key}.enabled=false) rendered without errors"
-
-extract_nginx "${RENDER_DIR}/disabled.yaml" "${RENDER_DIR}/nginx-disabled.conf"
-
-assert_absent "frontend nginx omits the mcpKubecost upstream when disabled" \
-  "${RENDER_DIR}/nginx-disabled.conf" "upstream mcpKubecost"
-assert_absent "frontend nginx omits /mcp proxy when disabled" \
-  "${RENDER_DIR}/nginx-disabled.conf" "location ^~ /mcp"
-assert_contains "productConfigs reports mcpEnabled=false" \
-  "${RENDER_DIR}/nginx-disabled.conf" '"mcpEnabled": "false"'
-
-# ---------------------------------------------------------------------------
-group "authMode routing guard"
-
-# There are two independent guards over MCP exposure:
-#
-# Guard 1 — subchart sanityChecks (mcp-kubecost.sanityChecks):
-#   mcp.httpRoute.enabled=true OR mcp.ingress.enabled=true WITH authMode=none
-#   is always a hard fail. skipSanityChecks does NOT bypass it (that flag only
-#   skips live Secret lookups).
-#
-# Guard 2 — parent openRouteCheck (kubecost.mcp.openRouteCheck):
-#   Fires ONLY when ALL THREE of these are simultaneously true:
-#     - a parent route is exposed (ingress.enabled or httpRoute.enabled)
-#     - kubecostApiPort is 9008 (aggregator SSO bypass port)
-#     - authMode is "none"
-#   When skipSanityChecks is set, this becomes a warning rather than a hard fail.
-#   Missing any one of the three conditions means no error is raised.
-#
-# nginx proxy behaviour (kubecost.frontend.mcpProxyDirectives):
-#   The helper is unconditional — it always emits proxy_pass directives.
-#   ingress.enabled, httpRoute.enabled, and authMode do not affect whether
-#   proxy_pass or 424 appears in the rendered nginx config. The MCP location
-#   blocks are only rendered at all when mcp.enabled=true.
-
-_subchart_route_fail='authMode "none" with an exposed route is not permitted'
-_parent_route_fail='mcp.config.authMode is "none"'
-
-# ---------------------------------------------------------------------------
-# Guard 1: subchart route flags + authMode=none must FAIL regardless of port.
-# ---------------------------------------------------------------------------
-
-assert_helm_fails "when mcp.httpRoute.enabled=true and authMode=none" \
-  "$_subchart_route_fail" \
-  --set mcp.httpRoute.enabled=true \
-  --set mcp.config.authMode=none
-
-assert_helm_fails "when mcp.ingress.enabled=true and authMode=none" \
-  "$_subchart_route_fail" \
-  --set mcp.ingress.enabled=true \
-  --set mcp.config.authMode=none
-
-# skipSanityChecks must NOT bypass the subchart's hard fail.
-assert_helm_fails "when mcp.httpRoute.enabled=true, authMode=none, and skipSanityChecks=true" \
-  "$_subchart_route_fail" \
-  --set mcp.httpRoute.enabled=true \
-  --set mcp.config.authMode=none \
-  --set global.platforms.cicd.enabled=true \
-  --set global.platforms.cicd.skipSanityChecks=true
-
-# 0.14.0 requires route identity after the authMode guard. authMode=open reaches
-# these checks; an incomplete route must still fail rather than publish a host.
-assert_helm_fails "when mcp.httpRoute.enabled=true but parentRefs is empty" \
-  "mcp.httpRoute.parentRefs is empty" \
-  --set mcp.httpRoute.enabled=true \
-  --set mcp.config.authMode=open
-
-assert_helm_fails "when mcp.ingress.enabled=true but hosts is empty" \
-  "mcp.ingress.hosts is empty" \
-  --set mcp.ingress.enabled=true \
-  --set mcp.config.authMode=open
-
-# ---------------------------------------------------------------------------
-# Guard 2: parent openRouteCheck — 3-way AND (route AND port=9008 AND authMode=none)
-# ---------------------------------------------------------------------------
-
-# All three conditions present → hard fail.
-assert_helm_fails "when ingress.enabled=true, kubecostApiPort=9008, and authMode=none" \
-  "$_parent_route_fail" \
-  --set ingress.enabled=true \
-  --set mcp.config.kubecostApiPort=9008 \
-  --set mcp.config.authMode=none
-
-assert_helm_fails "when httpRoute.enabled=true, kubecostApiPort=9008, and authMode=none" \
-  "$_parent_route_fail" \
-  --set httpRoute.enabled=true \
-  --set mcp.config.kubecostApiPort=9008 \
-  --set mcp.config.authMode=none
-
-# Route + port9008 + authMode=none + skipSanityChecks → warning only (render succeeds).
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set ingress.enabled=true \
-  --set mcp.config.kubecostApiPort=9008 \
-  --set mcp.config.authMode=none \
-  --set global.platforms.cicd.enabled=true \
-  --set global.platforms.cicd.skipSanityChecks=true \
-  > "${RENDER_DIR}/ingress-9008-none-skip.yaml"
-pass "helm template succeeds (warning) when ingress+kubecostApiPort=9008+authMode=none+skipSanityChecks"
-
-# Missing one condition: route present, port 9008, but authMode != none → no error.
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set ingress.enabled=true \
-  --set mcp.config.kubecostApiPort=9008 \
-  --set mcp.config.authMode=open \
-  > /dev/null
-pass "openRouteCheck does not fire when route+port9008 but authMode=open"
-
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set ingress.enabled=true \
-  --set ingress.hosts[0]=kubecost.example.com \
-  --set mcp.config.kubecostApiPort=9008 \
-  --set mcp.config.authMode=oidc \
-  --set mcp.config.oidc.clientID=test-client-id \
-  --set mcp.config.oidc.clientSecret=test-client-secret \
-  --set mcp.config.oidc.issuerUrl=https://auth.example.com \
-  --set mcp.config.externalUrl=https://kubecost.example.com \
-  > /dev/null
-pass "openRouteCheck does not fire when route+port9008 but authMode=oidc"
-
-# Missing one condition: route present, authMode=none, but default port (9004) → no error.
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set ingress.enabled=true \
-  --set mcp.config.authMode=none \
-  > /dev/null
-pass "openRouteCheck does not fire when ingress+authMode=none but default port 9004"
-
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set httpRoute.enabled=true \
-  --set mcp.config.authMode=none \
-  > /dev/null
-pass "openRouteCheck does not fire when httpRoute+authMode=none but default port 9004"
-
-# Missing one condition: port 9008, authMode=none, but no route -> no error.
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set mcp.config.kubecostApiPort=9008 \
-  --set mcp.config.authMode=none \
-  > /dev/null
-pass "openRouteCheck does not fire when port9008+authMode=none but no route is exposed"
-
-# ---------------------------------------------------------------------------
-# nginx proxy behaviour: kubecost.frontend.mcpProxyDirectives is unconditional.
-# The helper always emits proxy_pass regardless of ingress, httpRoute, or authMode.
-# ---------------------------------------------------------------------------
-
-# Baseline: default render (no ingress, no httpRoute, authMode=none) → proxy_pass.
-extract_nginx "${RENDER_DIR}/enabled.yaml" "${RENDER_DIR}/nginx-baseline.conf"
-assert_contains "nginx proxies /mcp with default settings (no ingress, authMode=none)" \
-  "${RENDER_DIR}/nginx-baseline.conf" "proxy_pass http://mcpKubecost"
-assert_absent "nginx does not emit 424 with default settings" \
-  "${RENDER_DIR}/nginx-baseline.conf" "return 424"
-
-# authMode=open, no parent ingress/httpRoute → proxy_pass.
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set mcp.config.authMode=open \
-  > "${RENDER_DIR}/no-route-open.yaml"
-extract_nginx "${RENDER_DIR}/no-route-open.yaml" "${RENDER_DIR}/nginx-no-route-open.conf"
-assert_contains "nginx proxies /mcp when authMode=open and no parent ingress/httpRoute" \
-  "${RENDER_DIR}/nginx-no-route-open.conf" "proxy_pass http://mcpKubecost"
-assert_absent "nginx does not emit 424 when authMode=open and no parent ingress/httpRoute" \
-  "${RENDER_DIR}/nginx-no-route-open.conf" "return 424"
-
-# authMode=none, ingress.enabled → proxy_pass (nginx has no awareness of ingress).
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set ingress.enabled=true \
-  --set mcp.config.authMode=none \
-  > "${RENDER_DIR}/ingress-none.yaml"
-extract_nginx "${RENDER_DIR}/ingress-none.yaml" "${RENDER_DIR}/nginx-ingress-none.conf"
-assert_contains "nginx proxies /mcp when ingress.enabled and authMode=none" \
-  "${RENDER_DIR}/nginx-ingress-none.conf" "proxy_pass http://mcpKubecost"
-assert_absent "nginx does not emit 424 when ingress.enabled and authMode=none" \
-  "${RENDER_DIR}/nginx-ingress-none.conf" "return 424"
-
-# authMode=open, ingress.enabled → proxy_pass.
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set ingress.enabled=true \
-  --set mcp.config.authMode=open \
-  > "${RENDER_DIR}/ingress-open.yaml"
-extract_nginx "${RENDER_DIR}/ingress-open.yaml" "${RENDER_DIR}/nginx-ingress-open.conf"
-assert_contains "nginx proxies /mcp when ingress.enabled and authMode=open" \
-  "${RENDER_DIR}/nginx-ingress-open.conf" "proxy_pass http://mcpKubecost"
-assert_absent "nginx does not emit 424 when ingress.enabled and authMode=open" \
-  "${RENDER_DIR}/nginx-ingress-open.conf" "return 424"
-
-# authMode=none, httpRoute.enabled → proxy_pass.
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set httpRoute.enabled=true \
-  --set mcp.config.authMode=none \
-  > "${RENDER_DIR}/httproute-none.yaml"
-extract_nginx "${RENDER_DIR}/httproute-none.yaml" "${RENDER_DIR}/nginx-httproute-none.conf"
-assert_contains "nginx proxies /mcp when httpRoute.enabled and authMode=none" \
-  "${RENDER_DIR}/nginx-httproute-none.conf" "proxy_pass http://mcpKubecost"
-assert_absent "nginx does not emit 424 when httpRoute.enabled and authMode=none" \
-  "${RENDER_DIR}/nginx-httproute-none.conf" "return 424"
-
-# authMode=open, httpRoute.enabled → proxy_pass.
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set httpRoute.enabled=true \
-  --set mcp.config.authMode=open \
-  > "${RENDER_DIR}/httproute-open.yaml"
-extract_nginx "${RENDER_DIR}/httproute-open.yaml" "${RENDER_DIR}/nginx-httproute-open.conf"
-assert_contains "nginx proxies /mcp when httpRoute.enabled and authMode=open" \
-  "${RENDER_DIR}/nginx-httproute-open.conf" "proxy_pass http://mcpKubecost"
-assert_absent "nginx does not emit 424 when httpRoute.enabled and authMode=open" \
-  "${RENDER_DIR}/nginx-httproute-open.conf" "return 424"
-
-# mcp.httpRoute.enabled (subchart route, not parent): the frontend nginx MCP proxy
-# block is suppressed entirely — the subchart's HTTPRoute handles external traffic
-# directly. Nginx must NOT contain any MCP proxy_pass or location /mcp for these.
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set mcp.httpRoute.enabled=true \
-  --set mcp.httpRoute.parentRefs[0].name=mcp-gateway \
-  --set mcp.httpRoute.hostnames[0]=mcp.example.com \
-  --set mcp.config.authMode=open \
-  > "${RENDER_DIR}/mcp-httproute-open.yaml"
-extract_nginx "${RENDER_DIR}/mcp-httproute-open.yaml" "${RENDER_DIR}/nginx-mcp-httproute-open.conf"
-assert_absent "nginx omits proxy_pass http://mcpKubecost when mcp.httpRoute.enabled (subchart route handles traffic)" \
-  "${RENDER_DIR}/nginx-mcp-httproute-open.conf" "proxy_pass http://mcpKubecost"
-assert_absent "nginx omits location /mcp when mcp.httpRoute.enabled (subchart route handles traffic)" \
-  "${RENDER_DIR}/nginx-mcp-httproute-open.conf" "location ^~ /mcp"
-
-# OIDC nginx rendering: port 9008 + authMode=oidc with full required OIDC params.
-# openRouteCheck does not fire (authMode != none), and the subchart renders cleanly.
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set mcp.config.kubecostApiPort=9008 \
-  --set mcp.config.authMode=oidc \
-  --set mcp.config.oidc.clientID=test-client-id \
-  --set mcp.config.oidc.clientSecret=test-client-secret \
-  --set mcp.config.oidc.issuerUrl=https://auth.example.com \
-  --set mcp.config.externalUrl=https://kubecost.example.com \
-  > "${RENDER_DIR}/apiport-9008-oidc.yaml"
-pass "helm template succeeds when kubecostApiPort=9008 and authMode=oidc"
-
-extract_nginx "${RENDER_DIR}/apiport-9008-oidc.yaml" "${RENDER_DIR}/nginx-oidc.conf"
-assert_contains "nginx proxies the fixed OAuth prefix when authMode=oidc" \
-  "${RENDER_DIR}/nginx-oidc.conf" "location ^~ /oauth/mcp/"
-assert_contains "nginx proxies RFC 9728 protected-resource metadata" \
-  "${RENDER_DIR}/nginx-oidc.conf" "location ^~ /.well-known/oauth-protected-resource/mcp"
-assert_contains "nginx proxies RFC 8414 authorization-server metadata" \
-  "${RENDER_DIR}/nginx-oidc.conf" "location ^~ /.well-known/oauth-authorization-server/oauth/mcp"
-assert_contains "nginx proxies the OIDC discovery alias" \
-  "${RENDER_DIR}/nginx-oidc.conf" "location ^~ /.well-known/openid-configuration/oauth/mcp"
-assert_absent "nginx rewrites nothing — the subchart serves these paths verbatim" \
-  "${RENDER_DIR}/nginx-oidc.conf" "rewrite ^/mcp"
-assert_absent "nginx no longer claims the bare authorization-server well-known path" \
-  "${RENDER_DIR}/nginx-oidc.conf" "location ^~ /.well-known/oauth-authorization-server {"
-assert_contains "nginx proxies /mcp when authMode=oidc" \
-  "${RENDER_DIR}/nginx-oidc.conf" "proxy_pass http://mcpKubecost"
-assert_contains "productConfigs reports kubecostApiPort=9008" \
-  "${RENDER_DIR}/nginx-oidc.conf" '"kubecostApiPort": "9008"'
-
-# ---------------------------------------------------------------------------
-group "OIDC credential validation"
-
-# 6) authMode=oidc with no credentials must FAIL.
-set +e
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set mcp.config.authMode=oidc \
-  > /dev/null 2>&1
-_exit_code=$?
-set -e
-if [[ "$_exit_code" -eq 0 ]]; then
-  fail "helm template should have failed when authMode=oidc and no OIDC credentials are set"
-else
-  pass "helm template fails when authMode=oidc and no OIDC credentials (exit code ${_exit_code})"
-fi
-
-# 6b) skipSanityChecks does not bypass static OIDC validation. A complete OIDC
-# configuration still renders because the flag only skips live cluster lookups.
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set mcp.config.authMode=oidc \
-  --set mcp.config.oidc.clientID=test-client-id \
-  --set mcp.config.oidc.clientSecret=test-client-secret \
-  --set mcp.config.oidc.issuerUrl=https://auth.example.com \
-  --set mcp.config.externalUrl=https://kubecost.example.com \
-  --set global.platforms.cicd.enabled=true \
-  --set global.platforms.cicd.skipSanityChecks=true \
-  > "${RENDER_DIR}/oidc-none-creds-skip.yaml"
-pass "helm template succeeds with complete OIDC values when skipSanityChecks=true"
-
-assert_contains "skipSanityChecks OIDC render includes a ConfigMap" \
-  "${RENDER_DIR}/oidc-none-creds-skip.yaml" "kind: ConfigMap"
-
-# 7) authMode=oidc with inline clientID+clientSecret, issuerUrl, and externalUrl must SUCCEED.
-# The subchart validates all four fields; all must be present for a clean render.
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set mcp.config.authMode=oidc \
-  --set mcp.config.oidc.clientID=test-client-id \
-  --set mcp.config.oidc.clientSecret=test-client-secret \
-  --set mcp.config.oidc.issuerUrl=https://auth.example.com \
-  --set mcp.config.externalUrl=https://kubecost.example.com \
-  > "${RENDER_DIR}/oidc-inline-creds.yaml"
-pass "helm template succeeds when authMode=oidc with inline clientID+clientSecret"
-
-assert_contains "OIDC inline-creds render includes a ConfigMap" \
-  "${RENDER_DIR}/oidc-inline-creds.yaml" "kind: ConfigMap"
-
-# 8) authMode=oidc with existingSecret (satisfies credentials check) plus issuerUrl
-# and externalUrl must SUCCEED. skipSanityChecks is not needed since all required
-# OIDC fields are present.
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set mcp.config.authMode=oidc \
-  --set mcp.config.oidc.existingSecret=my-oidc-secret \
-  --set mcp.config.oidc.issuerUrl=https://auth.example.com \
-  --set mcp.config.externalUrl=https://kubecost.example.com \
-  > "${RENDER_DIR}/oidc-existing-secret.yaml"
-pass "helm template succeeds when authMode=oidc with existingSecret, issuerUrl, and externalUrl"
-
-assert_contains "OIDC existingSecret render includes a ConfigMap" \
-  "${RENDER_DIR}/oidc-existing-secret.yaml" "kind: ConfigMap"
-
-# 9) authMode=oidc with both inline and existingSecret must FAIL. The subchart
-# gives existingSecret precedence, so accepting both would leave unused sensitive
-# values in the Helm inputs and make the active credential source unclear.
-assert_helm_fails "when authMode=oidc has both inline credentials and existingSecret" \
-  "mcp.config.oidc.existingSecret cannot be combined with inline clientID or clientSecret values" \
-  --set mcp.config.authMode=oidc \
-  --set mcp.config.oidc.clientID=test-client-id \
-  --set mcp.config.oidc.clientSecret=test-client-secret \
-  --set mcp.config.oidc.existingSecret=my-oidc-secret \
-  --set mcp.config.oidc.issuerUrl=https://auth.example.com \
-  --set mcp.config.externalUrl=https://kubecost.example.com
-
-# A partial inline pair is also incompatible with existingSecret. It cannot be
-# used as a credential source and should not remain as an ignored sensitive value.
-assert_helm_fails "when authMode=oidc has existingSecret and a partial inline credential pair" \
-  "mcp.config.oidc.existingSecret cannot be combined with inline clientID or clientSecret values" \
-  --set mcp.config.authMode=oidc \
-  --set mcp.config.oidc.clientSecret=test-client-secret \
-  --set mcp.config.oidc.existingSecret=my-oidc-secret \
-  --set mcp.config.oidc.issuerUrl=https://auth.example.com \
-  --set mcp.config.externalUrl=https://kubecost.example.com
-
-# 10) mcp.config.externalUrl must match the hostname of the enabled Kubecost route,
-# since the frontend is what serves /mcp and /oauth/mcp.
-assert_helm_fails "when externalUrl does not match the Kubecost ingress host" \
-  "is not one of the Kubecost route's hostnames" \
-  --set mcp.config.authMode=oidc \
-  --set mcp.config.oidc.clientID=test-client-id \
-  --set mcp.config.oidc.clientSecret=test-client-secret \
-  --set mcp.config.oidc.issuerUrl=https://auth.example.com \
-  --set ingress.enabled=true \
-  --set "ingress.hosts[0]=kubecost.example.com" \
-  --set mcp.config.externalUrl=https://wrong.example.com
-
-# 11) mcp.config.oidc.baseUrl was removed in mcp-kubecost 0.12.0. The subchart's
-# schema is additionalProperties: false, so a stale value is rejected outright
-# rather than silently ignored.
-set +e
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  --set "${values_key}.enabled=true" \
-  --set mcp.config.oidc.baseUrl=https://kubecost.example.com \
-  > /dev/null 2>"${RENDER_DIR}/stale-baseurl.err"
-_exit_code=$?
-set -e
-if [[ "$_exit_code" -eq 0 ]]; then
-  fail "helm template should have rejected the removed mcp.config.oidc.baseUrl key"
-else
-  assert_contains "stale mcp.config.oidc.baseUrl is rejected by the subchart schema" \
-    "${RENDER_DIR}/stale-baseurl.err" "additional properties 'baseUrl' not allowed"
-fi
-
-# ---------------------------------------------------------------------------
-group "global: values conformance"
-
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set global.imageRegistry=test-registry.io \
-  --set 'global.imagePullSecrets={global-pull-secret}' \
-  --set 'global.additionalLabels.kubecost\.com/conformance=global-labels' \
-  --set 'global.annotations.kubecost\.com/conformance=global-annotations' \
-  --set 'global.podAnnotations.kubecost\.com/conformance=global-pod-annotations' \
-  > "${RENDER_DIR}/globals.yaml"
-pass "helm template with global overrides rendered without errors"
-
-yq -r \
-  "select(.kind == \"Deployment\" and .metadata.name == \"${expected_fullname}\")" \
-  "${RENDER_DIR}/globals.yaml" > "${RENDER_DIR}/globals-deployment.yaml"
-
-overridden_image="$(yq -r '.spec.template.spec.containers[0].image' \
-  "${RENDER_DIR}/globals-deployment.yaml")"
-assert_eq "global.imageRegistry overrides the subchart image registry" \
-  "test-registry.io/kubecost/mcp-kubecost:${dep_version#v}" "$overridden_image"
-
-pull_secret="$(yq -r '.spec.template.spec.imagePullSecrets[0].name' \
-  "${RENDER_DIR}/globals-deployment.yaml")"
-assert_eq "global.imagePullSecrets is inherited by the subchart" \
-  "global-pull-secret" "$pull_secret"
-
-meta_label="$(yq -r '.metadata.labels."kubecost.com/conformance"' \
-  "${RENDER_DIR}/globals-deployment.yaml")"
-assert_eq "global.additionalLabels lands on the subchart Deployment" \
-  "global-labels" "$meta_label"
-
-pod_label="$(yq -r '.spec.template.metadata.labels."kubecost.com/conformance"' \
-  "${RENDER_DIR}/globals-deployment.yaml")"
-assert_eq "global.additionalLabels lands on the subchart pod template" \
-  "global-labels" "$pod_label"
-
-selector_label="$(yq -r '.spec.selector.matchLabels."kubecost.com/conformance"' \
-  "${RENDER_DIR}/globals-deployment.yaml")"
-assert_eq "global.additionalLabels stays out of the immutable selector" \
-  "null" "$selector_label"
-
-meta_annotation="$(yq -r '.metadata.annotations."kubecost.com/conformance"' \
-  "${RENDER_DIR}/globals-deployment.yaml")"
-assert_eq "global.annotations lands on the subchart Deployment" \
-  "global-annotations" "$meta_annotation"
-
-pod_annotation="$(yq -r '.spec.template.metadata.annotations."kubecost.com/conformance"' \
-  "${RENDER_DIR}/globals-deployment.yaml")"
-assert_eq "global.podAnnotations lands on the subchart pod template" \
-  "global-pod-annotations" "$pod_annotation"
-
-# The subchart must keep its own config-reload checksum alongside global annotations.
-checksum="$(yq -r '.spec.template.metadata.annotations."checksum/config"' \
-  "${RENDER_DIR}/globals-deployment.yaml")"
-if [ "$checksum" = "null" ] || [ -z "$checksum" ]; then
-  fail "global.podAnnotations clobbered the subchart's checksum/config annotation"
-else
-  pass "subchart checksum/config annotation survives global.podAnnotations"
-fi
-
-# No stale icr.io reference should remain in the subchart resources once the
-# registry is overridden.
-assert_absent "no hardcoded icr.io in the subchart Deployment after override" \
-  "${RENDER_DIR}/globals-deployment.yaml" "icr.io"
-
-# --- OpenShift adaptation --------------------------------------------------
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set global.platforms.openshift.enabled=true \
-  > "${RENDER_DIR}/openshift.yaml"
-pass "helm template with global.platforms.openshift.enabled=true rendered"
-
-yq -r \
-  "select(.kind == \"Deployment\" and .metadata.name == \"${expected_fullname}\") | .spec.template.spec.securityContext" \
-  "${RENDER_DIR}/openshift.yaml" > "${RENDER_DIR}/openshift-sc.yaml"
-
-ocp_run_as_user="$(yq -r '.runAsUser' "${RENDER_DIR}/openshift-sc.yaml")"
-assert_eq "OpenShift render drops the explicit runAsUser (restricted-v2 SCC)" \
-  "null" "$ocp_run_as_user"
-
-ocp_run_as_non_root="$(yq -r '.runAsNonRoot' "${RENDER_DIR}/openshift-sc.yaml")"
-assert_eq "OpenShift render keeps runAsNonRoot" "true" "$ocp_run_as_non_root"
-
-# Non-OpenShift renders must keep the chart's hardened UID/GID.
-default_run_as_user="$(yq -r \
-  "select(.kind == \"Deployment\" and .metadata.name == \"${expected_fullname}\") | .spec.template.spec.securityContext.runAsUser" \
-  "${RENDER_DIR}/enabled.yaml")"
-assert_eq "default render keeps the subchart's non-root UID" \
-  "65532" "$default_run_as_user"
-
-# --- CI/CD sanity-check bypass --------------------------------------------
-helm template "$RELEASE_NAME" "$CHART_DIR" \
-  "${skip_schema[@]}" \
-  --set "${values_key}.enabled=true" \
-  --set global.platforms.cicd.enabled=true \
-  --set global.platforms.cicd.skipSanityChecks=true \
-  --set "${values_key}.config.kubecostApiKey.existingSecret=does-not-exist" \
-  > "${RENDER_DIR}/cicd.yaml"
-pass "global.platforms.cicd.skipSanityChecks lets the subchart render for Argo CD"
-
-assert_contains "subchart reads the API key from the referenced Secret" \
-  "${RENDER_DIR}/cicd.yaml" "name: does-not-exist"
 
 # ---------------------------------------------------------------------------
 group "Summary"
 
-if [ "$failures" -ne 0 ]; then
-  printf '%s check(s) failed.\n' "$failures" >&2
+if [ "$failures" -eq 0 ]; then
+  printf '\nAll mcp-kubecost subchart checks passed.\n'
+else
+  printf '\n%d mcp-kubecost subchart check(s) failed.\n' "$failures" >&2
   exit 1
 fi
-printf 'All mcp-kubecost subchart checks passed.\n'

--- a/.github/workflows/validate-mcp-subchart.yml
+++ b/.github/workflows/validate-mcp-subchart.yml
@@ -10,6 +10,8 @@ on:
       - 'kubecost/templates/NOTES.txt'
       - 'kubecost/templates/frontend/_helpers.tpl'
       - 'kubecost/templates/frontend/frontend-configmap.yaml'
+      - 'kubecost/tests/**'
+      - 'kubecost/values-*.yaml'
       - '.github/scripts/validate_mcp_subchart.sh'
       - '.github/workflows/validate-mcp-subchart.yml'
   workflow_dispatch: {}
@@ -37,6 +39,9 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v5
 
+      - name: Install helm-unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version 1.1.2
+
       # ubuntu-latest ships yq, but pin it so assertion syntax cannot drift
       # when the runner image is updated.
       - name: Set up yq
@@ -61,8 +66,7 @@ jobs:
       - name: Build chart dependencies
         run: helm dependency build "$CHART_DIR"
 
-      # helm lint with the subchart enabled, helm template for the default and
-      # enabled cases, resource assertions, and the global: conformance checks.
+      # Dependency pinning, helm lint, and the helm-unittest suites.
       - name: Validate mcp-kubecost subchart integration
         env:
           MCP_SUBCHART_SKIP_DEP_BUILD: "1"
@@ -72,29 +76,16 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .helm-render
+          helm template kubecost "$CHART_DIR" > .helm-render/mcp-enabled.yaml
           helm template kubecost "$CHART_DIR" \
-            --skip-schema-validation \
-            --set mcp.enabled=true \
-            > .helm-render/mcp-enabled.yaml
-          helm template kubecost "$CHART_DIR" \
-            --skip-schema-validation \
-            --set mcp.enabled=true \
             --set mcp.httpRoute.enabled=true \
             --set mcp.httpRoute.parentRefs[0].name=mcp-gateway \
             --set mcp.httpRoute.hostnames[0]=mcp.example.com \
-            --set mcp.config.authMode=open \
+            --set mcp.config.requireClientApiKey=true \
             --set mcp.config.kubecostApiKey.existingSecret=kubecost-api-key \
             --set global.platforms.cicd.enabled=true \
             --set global.platforms.cicd.skipSanityChecks=true \
             > .helm-render/mcp-httproute.yaml
-          helm template kubecost "$CHART_DIR" \
-            --skip-schema-validation \
-            --set mcp.enabled=true \
-            --set mcp.httpRoute.enabled=true \
-            --set mcp.httpRoute.parentRefs[0].name=mcp-gateway \
-            --set mcp.httpRoute.hostnames[0]=mcp.example.com \
-            --set mcp.config.authMode=open \
-            > .helm-render/mcp-httproute-open.yaml
 
       # Ensure every rendered resource is valid Kubernetes YAML. HTTPRoute is a
       # Gateway API CRD, so that render tolerates missing schemas.

--- a/kubecost/.helmignore
+++ b/kubecost/.helmignore
@@ -21,3 +21,6 @@
 .idea/
 *.tmproj
 .vscode/
+
+# helm-unittest suites, not part of the packaged chart.
+/tests/

--- a/kubecost/README.md
+++ b/kubecost/README.md
@@ -38,8 +38,10 @@ Additionally, see the root of the chart for examples of commonly changed values 
 | `mcp.config.kubecostApiBaseUrl`               | Base URL the MCP server uses to reach the Kubecost aggregator                                                                                                       | `http://{{ .Release.Name }}-aggregator`               |
 | `mcp.config.kubecostApiPort`                  | Aggregator port for MCP queries. Use `9008` to bypass Kubecost's API authentication (only exposed when `saml.enabled` or `oidc.enabled`)                             | `9004`                                                |
 | `mcp.config.kubecostApiBasePath`              | API base path on the aggregator (it serves at the root, unlike the frontend's `/model` prefix)                                                                      | `/`                                                   |
-| `mcp.config.authMode`                         | Authentication for the MCP HTTP endpoint: `none`, `open`, `oidc`, or `api_key` [More info](https://github.com/kubecost/mcp-kubecost/tree/main/docs/auth)            | `none`                                                |
-| `mcp.config.externalUrl`                      | Public origin (scheme and host, no path) advertised in OAuth metadata. Required when `authMode` is `oidc` and MCP is proxied through the frontend                   | `""`                                                  |
+| `mcp.config.oidc.enabled`                     | Require a valid OIDC token on the MCP endpoint [More info](https://github.com/kubecost/mcp-kubecost/tree/main/docs/auth)                                            | `false`                                               |
+| `mcp.config.requireClientApiKey`              | Require an inbound `X-API-KEY` header on the MCP endpoint. Combines with OIDC                                                                                       | `false`                                               |
+| `mcp.allowUnauthenticatedExposure`            | Acknowledge exposing an unauthenticated MCP endpoint through a route                                                                                                | `false`                                               |
+| `mcp.config.externalUrl`                      | Public origin (scheme and host, no path) advertised in OAuth metadata. Required with OIDC when MCP is proxied through the frontend                                  | `""`                                                  |
 | `mcp.config.kubecostApiKey`                   | Outbound Kubecost API key sent as `X-API-KEY`. Prefer `existingSecret` over inline `value`                                                                          | `{value: "", existingSecret: "", key: KUBECOST_API_KEY}` |
 | `mcp.httpRoute.enabled`                       | If true, the MCP server gets its own Gateway API HTTPRoute and the frontend stops proxying `/mcp`                                                                   | `false`                                               |
 | `mcp.httpRoute.parentRefs`                    | Gateway(s) the HTTPRoute attaches to. Required when `mcp.httpRoute.enabled` is true                                                                                 | `[]`                                                  |
@@ -48,7 +50,7 @@ Additionally, see the root of the chart for examples of commonly changed values 
 | `mcp.ingress.className`                       | IngressClass name. Empty leaves the cluster's default IngressClass to claim it                                                                                      | `""`                                                  |
 | `mcp.ingress.hosts`                           | Hostnames routed to the MCP server. Required when `mcp.ingress.enabled` is true                                                                                     | `[]`                                                  |
 | `mcp.ingress.tls`                             | TLS secrets and their hostnames for the MCP Ingress                                                                                                                 | `[]`                                                  |
-| `mcp.persistence.enabled`                     | OAuth state PVC. `null` creates it only when `authMode` is `oidc`; `true` always; `false` never                                                                     | `null`                                                |
+| `mcp.persistence.enabled`                     | Back the OAuth state with a PVC. Only applies when `mcp.config.oidc.enabled` is true                                                                                 | `true`                                                |
 | `mcp.persistence.storageClass`                | StorageClass for the OAuth PVC. Falls back to `global.defaultStorageClass`, then the cluster default                                                                | `""`                                                  |
 | `mcp.nodeSelector` / `mcp.tolerations` / `mcp.affinity` | Scheduling for the MCP pod. The top-level `nodeSelector` does not cross the subchart boundary                                                              | `{}` / `[]` / `{}`                                    |
 
@@ -58,12 +60,13 @@ The chart deploys the [mcp-kubecost](https://github.com/kubecost/mcp-kubecost) F
 
 - The MCP endpoint is fixed at `/mcp` and its OAuth endpoints at `/oauth/mcp`.
 - The server is reachable in-cluster at `<release>-mcp:3030`, and by default the Kubecost frontend proxies both paths so MCP is available on the same hostname as the Kubecost UI.
-- Enabling `mcp.httpRoute.enabled` or `mcp.ingress.enabled` gives the MCP server its own external route, and the frontend then stops proxying `/mcp` and `/oauth/mcp`. Either route requires `mcp.config.authMode` to be set, plus its own hostnames (`mcp.httpRoute.parentRefs` and `mcp.httpRoute.hostnames`, or `mcp.ingress.hosts`) — the chart fails rather than publishing a placeholder host.
+- Enabling `mcp.httpRoute.enabled` or `mcp.ingress.enabled` gives the MCP server its own external route, and the frontend then stops proxying `/mcp` and `/oauth/mcp`. Either route requires its own hostnames (`mcp.httpRoute.parentRefs` and `mcp.httpRoute.hostnames`, or `mcp.ingress.hosts`) — the chart fails rather than publishing a placeholder host.
+- Two independent settings protect the MCP endpoint and they compose: `mcp.config.oidc.enabled` requires a valid OIDC token, and `mcp.config.requireClientApiKey` requires an inbound `X-API-KEY` header. Exposing a route with neither is rejected unless `mcp.allowUnauthenticatedExposure` is set.
 - The MCP server reads cost data through the Kubecost aggregator service, so it requires `aggregator.enabled` unless `mcp.config.kubecostApiBaseUrl` is repointed at an aggregator deployed elsewhere. If Kubecost is deployed with SAML or OIDC authentication, the MCP server needs its own OIDC configuration under `mcp.config.oidc`; when it has its own authentication, consider setting `mcp.config.kubecostApiPort` to `9008` to bypass Kubecost's API authentication. Note the aggregator Service only exposes `9008` when `saml.enabled` or `oidc.enabled` is true.
-- When using `authMode: oidc`, register `https://<mcp.config.externalUrl host>/oauth/mcp/callback` as the redirect URI at the IdP. `mcp.config.externalUrl` depends on the exposure topology, and the two are mutually exclusive:
+- With OIDC, register `https://<mcp.config.externalUrl host>/oauth/mcp/callback` as the redirect URI at the IdP. `mcp.config.externalUrl` depends on the exposure topology, and the two are mutually exclusive:
   - **Frontend-proxied** (the default): set it to the Kubecost hostname, which must be one of the top-level `ingress.hosts` / `httpRoute.hostnames`.
   - **MCP-owned route**: leave it empty and set `mcp.ingress.hosts` / `mcp.httpRoute.hostnames` instead; the subchart infers `externalUrl` from that hostname and rejects a value that disagrees with it.
-- With `authMode: oidc` the subchart also creates a `<release>-mcp-oauth` PVC for OAuth state. Control it with `mcp.persistence`; its StorageClass falls back to `global.defaultStorageClass`.
+- With OIDC the subchart also creates a `<release>-mcp-oauth` PVC for OAuth state. Control it with `mcp.persistence`; its StorageClass falls back to `global.defaultStorageClass`.
 
 ## Testing
 
@@ -87,4 +90,11 @@ If successful, you should see the following output:
 
 ```sh
 All charts linted and installed successfully
+```
+
+Template behaviour, including the mcp-kubecost subchart integration, is covered by
+[helm-unittest](https://github.com/helm-unittest/helm-unittest) suites in `kubecost/tests/`:
+
+```sh
+helm unittest kubecost
 ```

--- a/kubecost/templates/NOTES.txt
+++ b/kubecost/templates/NOTES.txt
@@ -49,4 +49,4 @@ Copyright IBM Corp. 2019-2026
 {{- include "kubecost.v3-postconditions" . -}}
 {{- include "kubecost.mcp.aggregatorCheck" . -}}
 {{- include "kubecost.mcp.openRouteCheck" . -}}
-{{- include "kubecost.mcp.validateOIDC" . -}}
+{{- include "kubecost.mcp.validateExternalUrl" . -}}

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -583,15 +583,34 @@ To resolve this, either:
 {{- end -}}
 {{- end -}}
 
-{{- define "kubecost.mcp.authMode" -}}
-{{- default "none" ((.Values.mcp).config).authMode -}}
-{{- end -}}
-
-{{- define "kubecost.mcp.requireClientApiKey" }}
-{{- if or (((.Values.mcp).config).requireClientApiKey) (eq (include "kubecost.mcp.authMode" .) "api_key") }}
+{{/*
+True when the frontend nginx serves MCP. Enabling a chart-managed route for the
+MCP server replaces the frontend proxy rather than adding to it.
+*/}}
+{{- define "kubecost.mcp.frontendProxied" -}}
+{{- if and (.Values.mcp).enabled (not ((.Values.mcp).httpRoute).enabled) (not ((.Values.mcp).ingress).enabled) -}}
 {{- printf "true" -}}
 {{- else -}}
 {{- printf "false" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "kubecost.mcp.oidcEnabled" -}}
+{{- if (((.Values.mcp).config).oidc).enabled -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{- define "kubecost.mcp.requireClientApiKey" -}}
+{{- if ((.Values.mcp).config).requireClientApiKey -}}true{{- else -}}false{{- end -}}
+{{- end -}}
+
+{{/*
+The MCP endpoint's protection, reported to the frontend. OIDC and an inbound API
+key are independent settings; OIDC is the stronger of the two when both are on.
+*/}}
+{{- define "kubecost.mcp.authMode" -}}
+{{- if eq (include "kubecost.mcp.oidcEnabled" .) "true" -}}oidc
+{{- else if eq (include "kubecost.mcp.requireClientApiKey" .) "true" -}}api_key
+{{- else -}}none
 {{- end -}}
 {{- end -}}
 
@@ -611,15 +630,15 @@ metadata, and the MCP SDK derives the well-known discovery URLs from them.
 {{- end -}}
 
 {{- define "kubecost.mcp.kubecostApiBaseUrl" -}}
-{{- tpl (default (printf "http://%s-aggregator" .Release.Name) ((.Values.mcp).config).kubecostApiBaseUrl) . -}}
+{{- tpl .Values.mcp.config.kubecostApiBaseUrl . -}}
 {{- end -}}
 
 {{- define "kubecost.mcp.kubecostApiPort" -}}
-{{- default 9004 ((.Values.mcp).config).kubecostApiPort -}}
+{{- .Values.mcp.config.kubecostApiPort -}}
 {{- end -}}
 
 {{- define "kubecost.mcp.kubecostApiBasePath" -}}
-{{- default "/" ((.Values.mcp).config).kubecostApiBasePath -}}
+{{- .Values.mcp.config.kubecostApiBasePath -}}
 {{- end -}}
 
 {{/*
@@ -644,27 +663,24 @@ frontend nginx upstream targets the same Service the subchart renders.
 {{- end -}}
 
 {{/*
-Fail when authMode is "none" AND a route (httpRoute or ingress) is exposed AND
-kubecostApiPort is 9008 (aggregator SSO bypass). All three conditions must be
-true simultaneously: a route alone at the default port (9004) is permitted, and
-port 9008 alone without an exposed route is also permitted. When CI/CD
-skipSanityChecks is set, emit a warning instead of failing.
-This does not prevent an mcp.httpRoute or mcp.ingress from being enabled. Those checks exist in the sub-chart itself.
+Fail when the MCP endpoint is unauthenticated AND externally reachable AND
+querying the aggregator on 9008, which bypasses Kubecost SSO. The subchart
+rejects its own unauthenticated route unless acknowledged, but it cannot see the
+Kubecost ingress that proxies MCP, and no acknowledgement covers an SSO bypass.
+When CI/CD skipSanityChecks is set, warn instead of failing.
 */}}
 {{- define "kubecost.mcp.openRouteCheck" -}}
 {{- if (.Values.mcp).enabled }}
 {{- $routeEnabled := or ((.Values.mcp).httpRoute).enabled ((.Values.mcp).ingress).enabled (.Values.ingress).enabled (.Values.httpRoute).enabled -}}
-{{- $apiPort := toString (include "kubecost.mcp.kubecostApiPort" .) -}}
-{{- $authMode := include "kubecost.mcp.authMode" . -}}
-{{- if and  ($routeEnabled) (eq $apiPort "9008") (eq $authMode "none") }}
+{{- $unauthenticated := eq (include "kubecost.mcp.authMode" .) "none" -}}
+{{- if and $routeEnabled $unauthenticated (eq (toString (include "kubecost.mcp.kubecostApiPort" .)) "9008") }}
 {{- if and .Values.global.platforms.cicd.enabled .Values.global.platforms.cicd.skipSanityChecks }}
 
-WARNING: MCP.CONFIG.AUTHMODE IS "NONE" WHILE an HTTPROUTE/INGRESS IS ENABLED AND MCP.CONFIG.KUBECOSTAPIPORT IS 9008.
-THE MCP ENDPOINT WOULD BE UNPROTECTED WHILE ABLE TO BYPASS KUBECOST SSO. SET MCP.CONFIG.AUTHMODE TO AT LEAST "OPEN"
-TO ACKNOWLEDGE THIS, OR USE "OIDC" OR "API_KEY" TO ENFORCE AUTHENTICATION.
-SKIPSANITYCHECKS IS TRUE SO THIS CHECK DID NOT FAIL.
+WARNING: THE MCP ENDPOINT IS UNAUTHENTICATED WHILE AN HTTPROUTE/INGRESS IS ENABLED AND
+MCP.CONFIG.KUBECOSTAPIPORT IS 9008, SO IT CAN BYPASS KUBECOST SSO. ENABLE MCP.CONFIG.OIDC.ENABLED
+OR MCP.CONFIG.REQUIRECLIENTAPIKEY. SKIPSANITYCHECKS IS TRUE SO THIS CHECK DID NOT FAIL.
 {{- else }}
-{{- fail "\n\nFAILURE: mcp.config.authMode is \"none\" while mcp.httpRoute or mcp.ingress is enabled, AND mcp.config.kubecostApiPort is 9008. The MCP endpoint would be unauthenticated while it can bypass Kubecost SSO on port 9008. Set mcp.config.authMode to at least \"open\" to acknowledge intentional unauthenticated exposure, or use \"oidc\" or \"api_key\" to enforce authentication.\n" }}
+{{- fail "\n\nFAILURE: the MCP endpoint is unauthenticated while an httpRoute or ingress is enabled, AND mcp.config.kubecostApiPort is 9008. It would be reachable externally while bypassing Kubecost SSO on port 9008. Enable mcp.config.oidc.enabled or mcp.config.requireClientApiKey.\n" }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -722,72 +738,21 @@ frontend, so the origin it advertises must be the Kubecost hostname.
 {{- end -}}
 
 {{/*
-Resolve and validate mcp.config.externalUrl, the public origin the MCP server
-advertises in its OAuth metadata. Mirrors mcp-kubecost.externalUrl in the
-subchart, but validates against the *parent* chart's route rather than the
-subchart's, because the frontend nginx is what serves MCP in this topology.
+The one MCP rule the subchart cannot check: it sees neither the parent's
+ingress.hosts nor its httpRoute.hostnames, and the frontend nginx is what serves
+MCP in the default topology. Credential, issuer, and externalUrl shape rules all
+live in mcp-kubecost.sanityChecks, which Helm renders first.
 
-Returns the trimmed origin, or "" when unset. Fails on a value that is not a
-bare https:// origin, or whose host is not one of the enabled Kubecost route's
-hostnames.
+Skipped when the MCP server owns its route, because the subchart then validates
+externalUrl against that route's own hostnames.
 */}}
-{{- define "kubecost.mcp.externalUrl" -}}
+{{- define "kubecost.mcp.validateExternalUrl" -}}
 {{- $explicit := (((.Values.mcp).config).externalUrl) | default "" | trim | trimSuffix "/" -}}
-{{- if $explicit -}}
-{{- if not (hasPrefix "https://" $explicit) -}}
-{{- fail (printf "\n\nFAILURE [kubecost / mcp]: mcp.config.externalUrl must be an https:// origin with no path: %s\n" $explicit) -}}
-{{- end -}}
+{{- if and $explicit (eq (include "kubecost.mcp.frontendProxied" .) "true") -}}
 {{- $host := trimPrefix "https://" $explicit -}}
-{{- if contains "/" $host -}}
-{{- fail (printf "\n\nFAILURE [kubecost / mcp]: mcp.config.externalUrl must be a bare origin with no path, query, or fragment: %s\n\n  The MCP endpoint is fixed at /mcp and its OAuth endpoints at /oauth/mcp; neither is configurable.\n" $explicit) -}}
-{{- end -}}
 {{- $routeHosts := include "kubecost.mcp.routeHosts" . | fromJsonArray -}}
-{{- if and (gt (len $routeHosts) 0) (not (has $host $routeHosts)) -}}
+{{- if and $routeHosts (not (has $host $routeHosts)) -}}
 {{- fail (printf "\n\nFAILURE [kubecost / mcp]: mcp.config.externalUrl host %q is not one of the Kubecost route's hostnames %v.\n\n  MCP is proxied through the Kubecost frontend, so it must advertise the same host clients reach Kubecost on.\n" $host $routeHosts) -}}
-{{- end -}}
-{{- $explicit -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-Validate the parent chart's MCP OIDC configuration. Credentials must come from
-exactly one source: a complete inline clientID/clientSecret pair or an
-existingSecret. Whitespace-only values are treated as unset.
-
-This parent-level check is intentional. It can validate the Kubecost frontend's
-route and provide parent value paths in errors; the subchart's standalone check
-cannot see that parent context. Keep the shared credential and URL rules aligned
-with mcp-kubecost.validateOIDC.
-*/}}
-{{- define "kubecost.mcp.validateOIDC" -}}
-{{- if (.Values.mcp).enabled -}}
-{{- $mode := default "none" ((.Values.mcp).config).authMode -}}
-{{- if eq $mode "oidc" -}}
-{{- $oidc := (((.Values.mcp).config).oidc) | default dict -}}
-{{- $clientID := trim ($oidc.clientID | default "") -}}
-{{- $clientSecret := trim ($oidc.clientSecret | default "") -}}
-{{- $hasAnyInline := or (not (empty $clientID)) (not (empty $clientSecret)) -}}
-{{- $hasInline := and (not (empty $clientID)) (not (empty $clientSecret)) -}}
-{{- $hasExisting := not (empty (trim ($oidc.existingSecret | default ""))) -}}
-{{- if not (or $hasInline $hasExisting) -}}
-{{- fail "\n\nFAILURE [kubecost / mcp]: mcp.config.authMode is \"oidc\" but no OIDC credentials are configured.\n\nTo fix, choose one of:\n  Option A — inline credentials:\n    mcp.config.oidc.clientID: \"<your-client-id>\"\n    mcp.config.oidc.clientSecret: \"<your-client-secret>\"\n\n  Option B — reference a pre-existing Secret (required keys: OIDC_CLIENT_ID, OIDC_CLIENT_SECRET):\n    mcp.config.oidc.existingSecret: \"<secret-name>\"\n" }}
-{{- end -}}
-{{- if and $hasAnyInline $hasExisting -}}
-{{- fail "\n\nFAILURE [kubecost / mcp]: mcp.config.oidc.existingSecret cannot be combined with inline clientID or clientSecret values.\nSupply exactly one credential source so the active credentials are unambiguous:\n\n  Option A — inline credentials only (remove existingSecret):\n    mcp.config.oidc.clientID: \"<your-client-id>\"\n    mcp.config.oidc.clientSecret: \"<your-client-secret>\"\n    mcp.config.oidc.existingSecret: \"\"\n\n  Option B — existing Secret only (remove clientID and clientSecret):\n    mcp.config.oidc.existingSecret: \"<secret-name>\"\n    mcp.config.oidc.clientID: \"\"\n    mcp.config.oidc.clientSecret: \"\"\n" }}
-{{- end -}}
-{{- /* Validate the shape and host of mcp.config.externalUrl when it is set. The
-     unset case is left to the subchart: Helm renders charts/ before templates/,
-     so mcp-kubecost.externalUrl always reports a missing value first. */}}
-{{- include "kubecost.mcp.externalUrl" . -}}
-{{- /* Mirrors mcp-kubecost.validateOIDC: RFC 8414 requires https, and the MCP
-     SDK carves out http:// on localhost / 127.0.0.1 for testing. Rejecting
-     more than the subchart does would fail installs the subchart accepts. */}}
-{{- $issuer := $oidc.issuerUrl | default "" -}}
-{{- $issuerHost := (urlParse $issuer).host | default "" | splitList ":" | first -}}
-{{- $issuerLocal := and (hasPrefix "http://" $issuer) (or (eq $issuerHost "localhost") (hasPrefix "127.0.0.1" $issuerHost)) -}}
-{{- if not (or (hasPrefix "https://" $issuer) $issuerLocal) -}}
-{{- fail "\n\nFAILURE [kubecost / mcp]: mcp.config.oidc.issuerUrl must be an https:// URL, or http:// on localhost / 127.0.0.1 for local testing.\n\n  Example:\n    mcp.config.oidc.issuerUrl: \"https://kubecost.example.com/.well-known/openid-configuration\"\n" }}
-{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -99,7 +99,7 @@ data:
     }
   {{- end }}
 
-  {{- if (.Values.mcp).enabled }}
+  {{- if eq (include "kubecost.mcp.frontendProxied" .) "true" }}
     upstream mcpKubecost {
         {{- if .Values.frontend.useDefaultFqdn }}
         server {{ include "kubecost.mcp.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ include "kubecost.mcp.servicePort" . }};
@@ -498,8 +498,7 @@ data:
         }
         {{- end }}
 
-        {{- /* mcpProxy: Only proxy MCP if it is enabled and not using its own httproute or ingress */}}
-        {{- if and (.Values.mcp).enabled (not ((.Values.mcp).httpRoute).enabled) (not ((.Values.mcp).ingress).enabled) }}
+        {{- if eq (include "kubecost.mcp.frontendProxied" .) "true" }}
         {{- $mcpPath := include "kubecost.mcp.path" . }}
         {{- $mcpOauth := include "kubecost.mcp.oauthPrefix" . }}
         {{- /*
@@ -512,12 +511,12 @@ data:
         location ^~ {{ $mcpPath }} {
             {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
         }
+        {{- if eq (include "kubecost.mcp.oidcEnabled" .) "true" }}
         {{- /* mcpOidc: OAuth endpoints, namespaced under {{ $mcpOauth }} so none of them
              claims a bare root path that collides with Kubecost SSO (/auth, /login,
              /logout, /oidc/, /saml/). */}}
-        {{- if eq (include "kubecost.mcp.authMode" .) "oidc" }}
         # {{ $mcpOauth }}/authorize, /token, /register, /consent and the IdP callback at {{ $mcpOauth }}/callback.
-        location ^~ {{ $mcpOauth }}/ {
+        location ^~ {{ $mcpOauth }} {
             {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
         }
 
@@ -534,6 +533,18 @@ data:
             {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
         }
         location ^~ /.well-known/openid-configuration{{ $mcpOauth }} {
+            {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
+        }
+
+        # Root-probe fallbacks for clients that never read the advertised URL. The
+        # suffixed locations above are longer prefixes, so they still win.
+        location ^~ /.well-known/oauth-protected-resource {
+            {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
+        }
+        location ^~ /.well-known/oauth-authorization-server {
+            {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
+        }
+        location ^~ /.well-known/openid-configuration {
             {{- include "kubecost.frontend.mcpProxyDirectives" . | nindent 12 }}
         }
         {{- end }}

--- a/kubecost/tests/mcp_frontend_test.yaml
+++ b/kubecost/tests/mcp_frontend_test.yaml
@@ -1,0 +1,111 @@
+suite: mcp frontend proxy and guards
+release:
+  name: kubecost
+templates:
+  - templates/frontend/frontend-configmap.yaml
+set:
+  mcp.config.oidc.issuerUrl: https://sso.example.com/.well-known/openid-configuration
+  mcp.config.oidc.existingSecret: mcp-oidc
+tests:
+  - it: proxies the MCP endpoint to the subchart Service
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'upstream mcpKubecost \{\s+server kubecost-mcp\.[^:]+:3030;'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location \^~ /mcp \{'
+
+  - it: leaves the OAuth locations out until OIDC is enabled
+    asserts:
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location \^~ /oauth/mcp'
+
+  - it: proxies every OAuth path the subchart's own routes publish
+    set:
+      mcp.config.oidc.enabled: true
+      mcp.config.externalUrl: https://kubecost.example.com
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location \^~ /oauth/mcp \{'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location \^~ /\.well-known/oauth-protected-resource/mcp \{'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location \^~ /\.well-known/oauth-authorization-server/oauth/mcp \{'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location \^~ /\.well-known/openid-configuration/oauth/mcp \{'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location \^~ /\.well-known/oauth-protected-resource \{'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location \^~ /\.well-known/oauth-authorization-server \{'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location \^~ /\.well-known/openid-configuration \{'
+
+  - it: relaxes form-action for the OAuth consent redirect chain
+    set:
+      mcp.config.oidc.enabled: true
+      mcp.config.externalUrl: https://kubecost.example.com
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: "add_header Content-Security-Policy \"default-src 'self'.*form-action \\*;\";"
+
+  - it: drops the proxy and its upstream when the MCP server owns its route
+    set:
+      mcp.config.requireClientApiKey: true
+      mcp.ingress.enabled: true
+      mcp.ingress.hosts:
+        - host: mcp.example.com
+    asserts:
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: 'upstream mcpKubecost'
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: 'location \^~ /mcp'
+
+  - it: drops the proxy and its upstream when MCP is disabled
+    set:
+      mcp.enabled: false
+    asserts:
+      - notMatchRegex:
+          path: data["nginx.conf"]
+          pattern: 'upstream mcpKubecost'
+
+  - it: reports the MCP configuration to the frontend
+    set:
+      mcp.config.oidc.enabled: true
+      mcp.config.externalUrl: https://kubecost.example.com
+      mcp.config.requireClientApiKey: true
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: '"mcpEnabled": "true"'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: '"mcpAuthMode": "oidc"'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: '"mcpRequireClientApiKey": "true"'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: '"kubecostApiBaseUrl": "http://kubecost-aggregator"'
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: '"kubecostApiPort": "9004"'
+
+  - it: reports api_key mode when only an inbound API key is required
+    set:
+      mcp.config.requireClientApiKey: true
+    asserts:
+      - matchRegex:
+          path: data["nginx.conf"]
+          pattern: '"mcpAuthMode": "api_key"'

--- a/kubecost/tests/mcp_guards_test.yaml
+++ b/kubecost/tests/mcp_guards_test.yaml
@@ -1,0 +1,71 @@
+suite: mcp exposure guards
+release:
+  name: kubecost
+templates:
+  - templates/NOTES.txt
+set:
+  mcp.config.oidc.issuerUrl: https://sso.example.com/.well-known/openid-configuration
+  mcp.config.oidc.existingSecret: mcp-oidc
+tests:
+  - it: refuses an unauthenticated MCP endpoint that is exposed and bypasses SSO
+    set:
+      ingress.enabled: true
+      mcp.config.kubecostApiPort: 9008
+    asserts:
+      - failedTemplate:
+          errorPattern: 'unauthenticated while an httpRoute or ingress is enabled'
+
+  - it: allows the SSO bypass port once the MCP endpoint enforces its own auth
+    set:
+      ingress.enabled: true
+      mcp.config.kubecostApiPort: 9008
+      mcp.config.requireClientApiKey: true
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: allows an exposed MCP endpoint on the authenticated aggregator port
+    set:
+      ingress.enabled: true
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: refuses an externalUrl that is not a Kubecost frontend hostname
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - kubecost.example.com
+      mcp.config.oidc.enabled: true
+      mcp.config.externalUrl: https://mcp.example.com
+    asserts:
+      - failedTemplate:
+          errorPattern: 'is not one of the Kubecost route.s hostnames'
+
+  - it: accepts an externalUrl that matches the Kubecost ingress hostname
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - kubecost.example.com
+      mcp.config.oidc.enabled: true
+      mcp.config.externalUrl: https://kubecost.example.com
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: leaves externalUrl to the subchart when the MCP server owns its route
+    set:
+      ingress.enabled: true
+      ingress.hosts:
+        - kubecost.example.com
+      mcp.config.oidc.enabled: true
+      mcp.ingress.enabled: true
+      mcp.ingress.hosts:
+        - host: mcp.example.com
+      mcp.config.externalUrl: https://mcp.example.com
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: warns when the MCP server points at an aggregator this release does not deploy
+    set:
+      aggregator.enabled: false
+    asserts:
+      - matchRegexRaw:
+          pattern: 'MCP.ENABLED IS TRUE BUT AGGREGATOR.ENABLED IS FALSE'

--- a/kubecost/tests/mcp_subchart_test.yaml
+++ b/kubecost/tests/mcp_subchart_test.yaml
@@ -1,0 +1,113 @@
+suite: mcp-kubecost subchart integration
+release:
+  name: kubecost
+templates:
+  - charts/mcp/templates/configmap.yaml
+  - charts/mcp/templates/deployment.yaml
+  - charts/mcp/templates/service.yaml
+  - charts/mcp/templates/secret.yaml
+  - charts/mcp/templates/pvc.yaml
+tests:
+  - it: deploys the MCP server by default
+    template: charts/mcp/templates/deployment.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: kubecost-mcp
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^icr\.io/kubecost/mcp-kubecost:'
+
+  - it: exposes the MCP server in-cluster on 3030
+    template: charts/mcp/templates/service.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: kubecost-mcp
+      - equal:
+          path: spec.ports[0].port
+          value: 3030
+
+  - it: points the MCP server at this release's aggregator, which serves at the root
+    template: charts/mcp/templates/configmap.yaml
+    asserts:
+      - equal:
+          path: data.KUBECOST_BASE_URL
+          value: http://kubecost-aggregator:9004
+      - equal:
+          path: data.KUBECOST_API_BASE_PATH
+          value: "/"
+
+  - it: tracks the release name in the aggregator URL
+    template: charts/mcp/templates/configmap.yaml
+    release:
+      name: other
+    asserts:
+      - equal:
+          path: data.KUBECOST_BASE_URL
+          value: http://other-aggregator:9004
+
+  - it: leaves the MCP endpoint unauthenticated by default
+    template: charts/mcp/templates/configmap.yaml
+    asserts:
+      - isNull:
+          path: data.AUTH_MODE
+      - equal:
+          path: data.REQUIRE_CLIENT_API_KEY
+          value: "false"
+
+  - it: passes global.imageRegistry into the subchart
+    template: charts/mcp/templates/deployment.yaml
+    set:
+      global.imageRegistry: public.ecr.aws
+      mcp.image.repository: kubecost/mcp-kubecost
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^public\.ecr\.aws/kubecost/mcp-kubecost:'
+
+  - it: passes global.additionalLabels and global.podAnnotations into the subchart
+    template: charts/mcp/templates/deployment.yaml
+    set:
+      global.additionalLabels:
+        team: finops
+      global.podAnnotations:
+        example.com/scrape: "true"
+    asserts:
+      - equal:
+          path: metadata.labels.team
+          value: finops
+      - equal:
+          path: spec.template.metadata.annotations["example.com/scrape"]
+          value: "true"
+      - exists:
+          path: spec.template.metadata.annotations["checksum/config"]
+
+  - it: passes global.defaultStorageClass to the OAuth PVC
+    template: charts/mcp/templates/pvc.yaml
+    set:
+      global.defaultStorageClass: gp3
+      mcp.config.oidc.enabled: true
+      mcp.config.oidc.issuerUrl: https://sso.example.com/.well-known/openid-configuration
+      mcp.config.oidc.existingSecret: mcp-oidc
+      mcp.config.externalUrl: https://kubecost.example.com
+    asserts:
+      - equal:
+          path: spec.storageClassName
+          value: gp3
+
+  - it: lets OpenShift assign the MCP pod's UID and GID
+    template: charts/mcp/templates/deployment.yaml
+    set:
+      global.platforms.openshift.enabled: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.securityContext.runAsUser
+
+  - it: names subchart values with the mcp prefix in its errors
+    template: charts/mcp/templates/deployment.yaml
+    set:
+      mcp.config.oidc.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: 'mcp\.config\.oidc\.enabled is true but its durable OAuth secrets are incomplete'

--- a/kubecost/values-windows-node-affinity.yaml
+++ b/kubecost/values-windows-node-affinity.yaml
@@ -4,3 +4,8 @@ nodeSelector:
 networkCosts:
   nodeSelector:
     kubernetes.io/os: linux
+
+# Subcharts do not inherit the top-level nodeSelector.
+mcp:
+  nodeSelector:
+    kubernetes.io/os: linux

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -656,138 +656,96 @@ finopsagent:
       spotLabel: ""
       spotLabelValue: ""
 
-## The FinOps MCP server for Kubecost analytics. Below are a subset of values from
-## the mcp-kubecost subchart that are most commonly changed.
-## Ref: https://github.com/kubecost/mcp-kubecost/blob/main/charts/mcp-kubecost/values.yaml
+## The FinOps MCP server for Kubecost analytics, deployed as the mcp-kubecost
+## subchart. Only the values that differ from that chart's own defaults are set
+## here; everything else it exposes can be set under `mcp:` and is documented at
+## https://github.com/kubecost/mcp-kubecost/blob/main/charts/mcp-kubecost/values.yaml
 ##
-## The MCP endpoint is fixed at /mcp and its OAuth endpoints at /oauth/mcp.
-## By default the Kubecost frontend proxies both, so MCP is reachable on the same hostname
-## as the Kubecost UI. Enable mcp.httpRoute or mcp.ingress below to give the MCP
-## server its own route instead, in which case the frontend stops proxying it.
+## The MCP endpoint is fixed at /mcp and its OAuth endpoints at /oauth/mcp. By
+## default the Kubecost frontend proxies both, so MCP is reachable on the same
+## hostname as the Kubecost UI. Enabling mcp.httpRoute or mcp.ingress gives the
+## MCP server its own route, and the frontend then stops proxying it.
 ##
 mcp:
   enabled: true
-  ## The MCP server reads cost data through the Kubecost aggregator service.
-  ## If Kubecost is deployed with SAML or OIDC authentication,
-  ## the MCP server must be configured with its own OIDC configuration.
-  ## When the mcp server has its own authentication, consider setting
-  ## mcp.config.kubecostApiPort to 9008 instead of 9004 to bypass Kubecost's API
-  ## authentication. The aggregator Service only exposes 9008 when saml.enabled or
-  ## oidc.enabled is true, so 9008 is a dead port on an installation without SSO.
+
+  ## The MCP server reads cost data through the aggregator, which serves its API
+  ## at the root rather than behind the frontend's /model prefix.
+  ##
+  ## If Kubecost is deployed with SAML or OIDC, give the MCP server its own
+  ## authentication under mcp.config.oidc and consider setting kubecostApiPort to
+  ## 9008 to bypass Kubecost's API authentication. The aggregator Service only
+  ## exposes 9008 when saml.enabled or oidc.enabled is true, so it is a dead port
+  ## on an installation without SSO.
   config:
     kubecostApiBaseUrl: "http://{{ .Release.Name }}-aggregator"
     kubecostApiPort: 9004
-    # The aggregator serves its API at the root, unlike the frontend's /model prefix.
     kubecostApiBasePath: "/"
-    ## Authentication for the MCP HTTP endpoint. One of: none, open, oidc, api_key.
-    ## The default of "none" leaves the endpoint unauthenticated inside the cluster.
-    ## See https://github.com/kubecost/mcp-kubecost/tree/main/docs/auth for more details.
-    authMode: none
-    # mcp.config.externalUrl is the public origin the MCP server advertises in its
-    # OAuth metadata — scheme and host only, no path. Required when authMode is
-    # "oidc". Which value it takes depends on how MCP is exposed; the two are
-    # mutually exclusive:
-    #
-    #   Frontend-proxied (the default, mcp.httpRoute and mcp.ingress both disabled):
-    #     set this to the Kubecost hostname, e.g. "https://kubecost.example.com".
-    #     It must be one of ingress.hosts / httpRoute.hostnames at the top level of
-    #     this file, because the frontend is what serves /mcp on that host.
-    #
-    #   MCP-owned route (mcp.httpRoute or mcp.ingress enabled below): leave this
-    #     empty and set the route's own hostname instead. The subchart infers this
-    #     value from that hostname, and rejects a value that disagrees with it.
-    externalUrl: ""
-    # mcp.config.kubecostApiKey is sent to Kubecost as an X-API-KEY request header for outbound calls.
-    # An MCP client may override it per request by sending its own X-API-KEY header.
-    kubecostApiKey:
-      # mcp.config.kubecostApiKey.value optionally creates a Secret containing the API key; prefer existingSecret.
-      value: ""
-      # mcp.config.kubecostApiKey.existingSecret is the name of a pre-created Secret containing the API key.
-      existingSecret: ""
-      # mcp.config.kubecostApiKey.key is the key within the existing or generated API-key Secret.
-      key: KUBECOST_API_KEY
-    # mcp.config.requireClientApiKey rejects inbound HTTP requests that arrive without an X-API-KEY header.
-    # When authMode is "api_key", this value is ignored and forced to true.
-    # Set it to true with authMode "oidc" to require both OIDC and an API key.
-    requireClientApiKey: false
-    # mcp.config.logLevel is the FastMCP log level. One of: DEBUG, INFO, WARNING, ERROR, CRITICAL.
-    logLevel: INFO
-    oidc:
-      # mcp.config.oidc.issuerUrl is the provider's .well-known/openid-configuration URL.
-      # Example: https://{domain}/.well-known/openid-configuration
-      issuerUrl: ""
-      # mcp.config.oidc.clientID is the OIDC client ID. Prefer existingSecret for production.
-      clientID: ""
-      # mcp.config.oidc.clientSecret is the OIDC client secret. Prefer existingSecret for production.
-      clientSecret: ""
-      # mcp.config.oidc.existingSecret references a pre-created Secret containing OIDC credentials.
-      # Required keys: OIDC_CLIENT_ID, OIDC_CLIENT_SECRET. Preferred over clientID/clientSecret.
-      # Supply either this or clientID/clientSecret, not both.
-      existingSecret: ""
-      # Register https://<mcp.config.externalUrl host>/oauth/mcp/callback as the redirect
-      # URI at the IdP. The callback path is fixed and cannot be changed.
-  ## The MCP server is reachable in-cluster at <release>-mcp:3030 and, by default,
-  ## through the Kubecost frontend. Enable one of these to give it its own external
-  ## ingress or HTTPRoute instead; the frontend then stops proxying /mcp and /oauth/mcp.
-  ## Either route requires mcp.config.authMode to be at least "open".
-  ##
-  ## These are a separate topology from the frontend proxy, not an addition to it.
-  ## Enabling one requires its hostnames below -- the subchart fails rather than
-  ## publishing a placeholder host -- and mcp.config.externalUrl is then inferred
-  ## from that hostname, so leave mcp.config.externalUrl empty.
-  ##
-  httpRoute:
-    enabled: false
-    # mcp.httpRoute.parentRefs is required when enabled. Reference the Gateway(s)
-    # this route attaches to.
-    # parentRefs:
-    #   - name: mcp-gateway
-    #     sectionName: https   # optional, listener name
-    # mcp.httpRoute.hostnames is required when enabled.
-    # hostnames:
-    #   - mcp.example.com
-    # annotations: {}
-  ingress:
-    enabled: false
-    # mcp.ingress.className is the IngressClass name. Empty leaves the cluster's
-    # default IngressClass to claim the Ingress.
-    # className: nginx
-    # mcp.ingress.hosts is required when enabled. The subchart generates the fixed
-    # /mcp, /oauth/mcp, and OAuth discovery paths for each host.
-    # hosts:
-    #   - host: mcp.example.com
-    # mcp.ingress.tls configures TLS secrets and their hostnames.
-    # tls:
-    #   - secretName: kubecost-mcp-server-tls
-    #     hosts:
-    #       - mcp.example.com
-    # Certificate issuance is left to the operator, e.g.:
-    # annotations:
-    #   cert-manager.io/cluster-issuer: letsencrypt-http
 
-  ## The MCP server stores its FastMCP OAuth registrations, grants, and tokens on a
-  ## PVC. mcp.persistence.enabled is tri-state: null (default) creates the PVC only
-  ## when mcp.config.authMode is "oidc", true always creates it, and false never
-  ## does -- with false, clients must re-register on every pod restart.
-  ## mcp.persistence.storageClass falls back to global.defaultStorageClass, and then
-  ## to the cluster's default StorageClass.
-  ##
-  persistence:
-    enabled: null
-    storageClass: ""
-    size: 1Gi
+    ## Require a valid OIDC token on the MCP endpoint. Register
+    ## https://<mcp.config.externalUrl host>/oauth/mcp/callback as the redirect URI
+    ## at the IdP; the callback path is fixed.
+    # oidc:
+    #   enabled: true
+    #   issuerUrl: "https://sso.example.com/.well-known/openid-configuration"
+    #   ## Name a pre-created Secret holding OIDC_CLIENT_ID and OIDC_CLIENT_SECRET.
+    #   ## Preferred over the inline clientID and clientSecret values.
+    #   existingSecret: ""
 
-  ## Scheduling for the MCP server pod. The chart's top-level nodeSelector does not
-  ## cross the subchart boundary, so set these when the cluster needs the MCP pod
-  ## constrained -- for example a mixed Windows/Linux cluster, where
-  ## values-windows-node-affinity.yaml pins the other components but not this one.
-  ##
-  nodeSelector: {}
-  tolerations: []
-  affinity: {}
+    ## Require an X-API-KEY header on inbound MCP requests. Combines with OIDC.
+    # requireClientApiKey: true
 
-  ## Resource requests and limits default to 250m/1Gi and 1000m/1Gi in the subchart.
-  ## Set them here only to override those defaults.
+    ## The public origin the MCP server advertises in its OAuth metadata: scheme
+    ## and host only. Required with OIDC when the frontend proxies MCP, and it
+    ## must be one of the top-level ingress.hosts / httpRoute.hostnames, because
+    ## the frontend is what serves /mcp on that host. Leave empty when
+    ## mcp.httpRoute or mcp.ingress is enabled; it is inferred from that route.
+    # externalUrl: "https://kubecost.example.com"
+
+    ## Sent to Kubecost as an X-API-KEY header on outbound calls. An MCP client
+    ## may override it per request with its own X-API-KEY header.
+    # kubecostApiKey:
+    #   ## Name a pre-created Secret holding the key, in preference to an inline value.
+    #   existingSecret: ""
+
+  ## Give the MCP server its own external route instead of the frontend proxy.
+  ## Enabling one requires its own hostnames -- the subchart fails rather than
+  ## publishing a placeholder host -- and requires authentication unless
+  ## mcp.allowUnauthenticatedExposure is set.
+  # httpRoute:
+  #   enabled: true
+  #   parentRefs:
+  #     - name: mcp-gateway
+  #       sectionName: https
+  #   hostnames:
+  #     - mcp.example.com
+  # ingress:
+  #   enabled: true
+  #   className: nginx
+  #   hosts:
+  #     - host: mcp.example.com
+  #   tls:
+  #     - secretName: kubecost-mcp-server-tls
+  #       hosts:
+  #         - mcp.example.com
+  #   annotations:
+  #     cert-manager.io/cluster-issuer: letsencrypt-http
+
+  ## The MCP server stores its OAuth registrations, grants, and tokens on a PVC
+  ## created when OIDC is enabled. Its storageClass falls back to
+  ## global.defaultStorageClass, then to the cluster's default StorageClass.
+  # persistence:
+  #   enabled: false
+  #   storageClass: ""
+  #   size: 1Gi
+
+  ## The chart's top-level nodeSelector does not cross the subchart boundary, so
+  ## set these when the MCP pod needs constraining.
+  # nodeSelector: {}
+  # tolerations: []
+  # affinity: {}
+
+  ## Defaults to 250m/1Gi requests and 1000m/1Gi limits in the subchart.
   # resources: {}
 
 ## Installs Kubecost/OpenCost plugins


### PR DESCRIPTION
## Release Notes Headline

Simplified the MCP Helm values and fixed the frontend proxy so it serves every OAuth discovery path the MCP server advertises.

## Commentary for Reviewers

Depends on kubecost/mcp-kubecost#76. Do not merge until that ships and `Chart.yaml`'s `0.14.1`
pin bumps.

- **`values.yaml`: 22 live MCP keys → 4.** The other 19 restated subchart defaults verbatim,
  pinning them; now commented examples.
- **`kubecost.mcp.validateOIDC` deleted** as unreachable — Helm renders `charts/` first, so the
  subchart's copy always won. Only the parent-only `externalUrl` route check survives.

## Links to Issues or Tickets

N/A

## User Impact and Risks

- **Bug:** the frontend proxied 4 of 8 MCP paths, missing the root-probe `/.well-known/*`
  fallbacks and the bare `/oauth/mcp`.
- **Bug:** `values-windows-node-affinity.yaml` pinned every component except MCP.
- `mcpAuthMode` no longer emits `open`, which matched `none` at runtime. `mcpEnabled` is
  unchanged.

## Testing

25 unittest assertions; `validate_mcp_subchart.sh` 821 → 121 lines. Dropped
`--skip-schema-validation`, which had disabled the subchart schema chart-wide. Full render
diffed before/after: same resource set.

## Documentation Updates

In this PR: `kubecost/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EuzFGwE9Yn3vVjZBP9nKD8
