### PR TITLE
CP: disable MCP subchart when aggregator.enabled=false (#4797)

### DIFF
--- a/.github/scripts/validate_mcp_subchart.sh
+++ b/.github/scripts/validate_mcp_subchart.sh
@@ -123,8 +123,8 @@ values_key="${dep_alias:-$SUBCHART_NAME}"
 
 assert_eq "dependency repository is the mcp-kubecost Helm repo" \
   "https://kubecost.github.io/mcp-kubecost" "$dep_repository"
-assert_eq "dependency condition gates the subchart" \
-  "${values_key}.enabled" "$dep_condition"
+assert_eq "dependency condition falls through to aggregator.enabled" \
+  "${values_key}.enabled,aggregator.enabled" "$dep_condition"
 
 if [ "$dep_version" = "*" ] || [ "${dep_version#\^}" != "$dep_version" ] \
   || [ "${dep_version#\~}" != "$dep_version" ]; then
@@ -140,7 +140,8 @@ assert_eq "${chart_lock} pins the same version as ${chart_yaml}" \
   "${dep_version#v}" "${lock_version#v}"
 
 default_enabled="$(yq -r ".[\"${values_key}\"].enabled" "${CHART_DIR}/values.yaml")"
-assert_eq "values.yaml defaults ${values_key}.enabled to true" "true" "$default_enabled"
+assert_eq "values.yaml omits ${values_key}.enabled so condition falls through to aggregator.enabled" \
+  "null" "$default_enabled"
 
 # ---------------------------------------------------------------------------
 group "Dependency resolution (validates Chart.lock is in sync)"
@@ -176,7 +177,7 @@ helm lint "$CHART_DIR" "${skip_schema[@]}" --set "${values_key}.enabled=true"
 pass "helm lint (--set ${values_key}.enabled=true)"
 
 # ---------------------------------------------------------------------------
-group "Subchart is enabled by default"
+group "Default-render behaviour (follows aggregator.enabled)"
 
 helm template "$RELEASE_NAME" "$CHART_DIR" "${skip_schema[@]}" > "${RENDER_DIR}/default.yaml"
 pass "helm template (defaults) rendered without errors"
@@ -186,10 +187,54 @@ pass "helm template (defaults) rendered without errors"
 default_sources="$(grep '^# Source:' "${RENDER_DIR}/default.yaml" || true)"
 # Helm uses the alias (when set) as the on-disk chart directory in # Source: lines.
 if printf '%s\n' "$default_sources" | grep -q "charts/${values_key}/"; then
-  pass "subchart resources rendered with ${values_key}.enabled=true (default)"
+  pass "subchart resources rendered by default when aggregator.enabled=true"
 else
-  fail "subchart rendered no resources despite ${values_key}.enabled=true (default)"
+  fail "subchart rendered no resources despite aggregator.enabled=true (default)"
 fi
+
+# aggregator.enabled=false with mcp.enabled unset must skip the subchart so
+# existing agent-only installs do not pick up MCP on upgrade.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set aggregator.enabled=false \
+  > "${RENDER_DIR}/aggregator-off.yaml"
+pass "helm template (aggregator.enabled=false) rendered without errors"
+
+aggregator_off_sources="$(grep '^# Source:' "${RENDER_DIR}/aggregator-off.yaml" || true)"
+if printf '%s\n' "$aggregator_off_sources" | grep -q "charts/${values_key}/"; then
+  fail "subchart rendered resources when aggregator.enabled=false and mcp.enabled is unset"
+else
+  pass "subchart is skipped when aggregator.enabled=false and mcp.enabled is unset"
+fi
+
+extract_nginx "${RENDER_DIR}/aggregator-off.yaml" "${RENDER_DIR}/nginx-aggregator-off.conf"
+assert_absent "frontend nginx omits the mcpKubecost upstream when aggregator is off" \
+  "${RENDER_DIR}/nginx-aggregator-off.conf" "upstream mcpKubecost"
+assert_contains "productConfigs reports mcpEnabled=false when aggregator is off" \
+  "${RENDER_DIR}/nginx-aggregator-off.conf" '"mcpEnabled": "false"'
+
+# An explicit mcp.enabled=true still deploys MCP with the aggregator off
+# (external aggregator). Skip schema: the subchart lookup for a missing
+# API-key Secret is not under test here.
+helm template "$RELEASE_NAME" "$CHART_DIR" \
+  "${skip_schema[@]}" \
+  --set aggregator.enabled=false \
+  --set "${values_key}.enabled=true" \
+  > "${RENDER_DIR}/mcp-forced-on.yaml"
+pass "helm template (aggregator.enabled=false, mcp.enabled=true) rendered without errors"
+
+forced_on_sources="$(grep '^# Source:' "${RENDER_DIR}/mcp-forced-on.yaml" || true)"
+if printf '%s\n' "$forced_on_sources" | grep -q "charts/${values_key}/"; then
+  pass "explicit mcp.enabled=true deploys the subchart even when aggregator is off"
+else
+  fail "explicit mcp.enabled=true did not deploy the subchart when aggregator is off"
+fi
+
+extract_nginx "${RENDER_DIR}/mcp-forced-on.yaml" "${RENDER_DIR}/nginx-mcp-forced-on.conf"
+assert_contains "productConfigs reports mcpEnabled=true when mcp.enabled=true overrides aggregator.enabled=false" \
+  "${RENDER_DIR}/nginx-mcp-forced-on.conf" '"mcpEnabled": "true"'
+assert_contains "frontend nginx defines the mcpKubecost upstream when mcp.enabled=true overrides aggregator.enabled=false" \
+  "${RENDER_DIR}/nginx-mcp-forced-on.conf" "upstream mcpKubecost"
 
 # ---------------------------------------------------------------------------
 group "Subchart renders expected resources"

--- a/.github/workflows/validate-mcp-subchart.yml
+++ b/.github/workflows/validate-mcp-subchart.yml
@@ -72,10 +72,26 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p .helm-render
+          # Default: mcp.enabled unset, aggregator.enabled=true (default) — MCP follows aggregator
+          helm template kubecost "$CHART_DIR" \
+            --skip-schema-validation \
+            > .helm-render/mcp-default.yaml
+          # Explicit mcp.enabled=true (backwards-compat / external aggregator path)
           helm template kubecost "$CHART_DIR" \
             --skip-schema-validation \
             --set mcp.enabled=true \
             > .helm-render/mcp-enabled.yaml
+          # aggregator.enabled=false, mcp.enabled unset — MCP must be absent
+          helm template kubecost "$CHART_DIR" \
+            --skip-schema-validation \
+            --set aggregator.enabled=false \
+            > .helm-render/aggregator-off.yaml
+          # aggregator.enabled=false, mcp.enabled=true — explicit override (external aggregator)
+          helm template kubecost "$CHART_DIR" \
+            --skip-schema-validation \
+            --set aggregator.enabled=false \
+            --set mcp.enabled=true \
+            > .helm-render/mcp-forced-on.yaml
           helm template kubecost "$CHART_DIR" \
             --skip-schema-validation \
             --set mcp.enabled=true \
@@ -98,11 +114,29 @@ jobs:
 
       # Ensure every rendered resource is valid Kubernetes YAML. HTTPRoute is a
       # Gateway API CRD, so that render tolerates missing schemas.
-      - name: Kubeconform (core resources)
+      - name: Kubeconform (default render — MCP follows aggregator.enabled)
+        uses: docker://ghcr.io/yannh/kubeconform:latest
+        with:
+          entrypoint: /kubeconform
+          args: -summary -strict -kubernetes-version 1.34.0 -ignore-missing-schemas -output text .helm-render/mcp-default.yaml
+
+      - name: Kubeconform (core resources — mcp.enabled=true)
         uses: docker://ghcr.io/yannh/kubeconform:latest
         with:
           entrypoint: /kubeconform
           args: -summary -strict -kubernetes-version 1.34.0 -ignore-missing-schemas -output text .helm-render/mcp-enabled.yaml
+
+      - name: Kubeconform (aggregator.enabled=false — MCP absent)
+        uses: docker://ghcr.io/yannh/kubeconform:latest
+        with:
+          entrypoint: /kubeconform
+          args: -summary -strict -kubernetes-version 1.34.0 -ignore-missing-schemas -output text .helm-render/aggregator-off.yaml
+
+      - name: Kubeconform (aggregator.enabled=false, mcp.enabled=true — explicit override)
+        uses: docker://ghcr.io/yannh/kubeconform:latest
+        with:
+          entrypoint: /kubeconform
+          args: -summary -strict -kubernetes-version 1.34.0 -ignore-missing-schemas -output text .helm-render/mcp-forced-on.yaml
 
       - name: Kubeconform (HTTPRoute render)
         uses: docker://ghcr.io/yannh/kubeconform:latest

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ gke_gcloud_auth_plugin_cache
 temp/
 cost-analyzer/
 kubecost/charts/.helm_ls_cache
+.bobtmp/
+.helm-render/

--- a/kubecost/Chart.lock
+++ b/kubecost/Chart.lock
@@ -5,5 +5,5 @@ dependencies:
 - name: mcp-kubecost
   repository: https://kubecost.github.io/mcp-kubecost
   version: 0.14.1
-digest: sha256:71669709b3bfa4c0cf1514224ae43aacd3b056ab0df21b5580186d564ed5f972
-generated: "2026-09-03T10:21:40.80118-04:00"
+digest: sha256:da016b3257b89e27709b74d9ff6cd7c55fa855d96a3c04c352b922eccc4a3674
+generated: "2026-09-09T08:54:20.510376-04:00"

--- a/kubecost/Chart.yaml
+++ b/kubecost/Chart.yaml
@@ -14,11 +14,15 @@ dependencies:
     version: "v1.0.25"
     repository: https://kubecost.github.io/finops-agent-chart
     condition: finopsagent.enabled
-  # The FinOps MCP server for Kubecost analytics. Enabled by default; the pinned
-  # version is bumped automatically by the mcp-kubecost release pipeline.
+  # The FinOps MCP server for Kubecost analytics. Follows aggregator.enabled
+  # unless mcp.enabled is set. The pinned version is bumped automatically by
+  # the mcp-kubecost release pipeline.
   # Ref: https://github.com/kubecost/mcp-kubecost
   - name: mcp-kubecost
     alias: mcp
     version: "0.14.1"
     repository: https://kubecost.github.io/mcp-kubecost
-    condition: mcp.enabled
+    # First boolean path wins. mcp.enabled is omitted from values.yaml so existing
+    # aggregator.enabled=false installs skip MCP on upgrade without a new flag.
+    # Set mcp.enabled to true or false to override.
+    condition: mcp.enabled,aggregator.enabled

--- a/kubecost/templates/_helpers.tpl
+++ b/kubecost/templates/_helpers.tpl
@@ -575,12 +575,17 @@ To resolve this, either:
 {{- end -}}
 {{- end -}}
 
-{{- define "kubecost.mcp.enabled" }}
-{{- if (.Values.mcp).enabled }}
-{{- printf "true" -}}
-{{- else -}}
-{{- printf "false" -}}
-{{- end -}}
+{{/*
+Whether the MCP subchart should be treated as enabled in parent templates.
+
+Mirrors Chart.yaml condition mcp.enabled,aggregator.enabled: an explicit
+boolean mcp.enabled wins, otherwise follow aggregator.enabled. Compare the
+result with eq "true"; a non-empty "false" string is truthy in Go templates.
+*/}}
+{{- define "kubecost.mcp.enabled" -}}
+{{- if kindIs "bool" ((.Values.mcp).enabled) -}}
+{{- if (.Values.mcp).enabled -}}true{{- else -}}false{{- end -}}
+{{- else if (.Values.aggregator).enabled -}}true{{- else -}}false{{- end -}}
 {{- end -}}
 
 {{- define "kubecost.mcp.authMode" -}}
@@ -652,7 +657,7 @@ skipSanityChecks is set, emit a warning instead of failing.
 This does not prevent an mcp.httpRoute or mcp.ingress from being enabled. Those checks exist in the sub-chart itself.
 */}}
 {{- define "kubecost.mcp.openRouteCheck" -}}
-{{- if (.Values.mcp).enabled }}
+{{- if eq (include "kubecost.mcp.enabled" .) "true" }}
 {{- $routeEnabled := or ((.Values.mcp).httpRoute).enabled ((.Values.mcp).ingress).enabled (.Values.ingress).enabled (.Values.httpRoute).enabled -}}
 {{- $apiPort := toString (include "kubecost.mcp.kubecostApiPort" .) -}}
 {{- $authMode := include "kubecost.mcp.authMode" . -}}
@@ -675,11 +680,11 @@ Warn when MCP is enabled but mcp.config.kubecostApiBaseUrl still resolves to an
 aggregator Service this release does not deploy; every MCP tool call would fail
 at runtime.
 
-Warns rather than fails: mcp.enabled defaults to true, so failing would block
-every existing aggregator-less install (including values-cac.yaml) on upgrade.
+Warns rather than fails: an explicit mcp.enabled=true with aggregator off is
+allowed for an external aggregator, but the default in-chart URL would be dead.
 */}}
 {{- define "kubecost.mcp.aggregatorCheck" -}}
-{{- if and (.Values.mcp).enabled (not (.Values.aggregator).enabled) }}
+{{- if and (eq (include "kubecost.mcp.enabled" .) "true") (not (.Values.aggregator).enabled) }}
 {{- $baseUrl := include "kubecost.mcp.kubecostApiBaseUrl" . -}}
 {{- $inChart := printf "http://%s" (include "kubecost.aggregator.serviceName" .) -}}
 {{- if or (eq $baseUrl $inChart) (hasPrefix (printf "%s." $inChart) $baseUrl) }}
@@ -760,7 +765,7 @@ cannot see that parent context. Keep the shared credential and URL rules aligned
 with mcp-kubecost.validateOIDC.
 */}}
 {{- define "kubecost.mcp.validateOIDC" -}}
-{{- if (.Values.mcp).enabled -}}
+{{- if eq (include "kubecost.mcp.enabled" .) "true" -}}
 {{- $mode := default "none" ((.Values.mcp).config).authMode -}}
 {{- if eq $mode "oidc" -}}
 {{- $oidc := (((.Values.mcp).config).oidc) | default dict -}}

--- a/kubecost/templates/frontend/frontend-configmap.yaml
+++ b/kubecost/templates/frontend/frontend-configmap.yaml
@@ -99,7 +99,7 @@ data:
     }
   {{- end }}
 
-  {{- if (.Values.mcp).enabled }}
+  {{- if eq (include "kubecost.mcp.enabled" .) "true" }}
     upstream mcpKubecost {
         {{- if .Values.frontend.useDefaultFqdn }}
         server {{ include "kubecost.mcp.serviceName" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ include "kubecost.mcp.servicePort" . }};
@@ -499,7 +499,7 @@ data:
         {{- end }}
 
         {{- /* mcpProxy: Only proxy MCP if it is enabled and not using its own httproute or ingress */}}
-        {{- if and (.Values.mcp).enabled (not ((.Values.mcp).httpRoute).enabled) (not ((.Values.mcp).ingress).enabled) }}
+        {{- if and (eq (include "kubecost.mcp.enabled" .) "true") (not ((.Values.mcp).httpRoute).enabled) (not ((.Values.mcp).ingress).enabled) }}
         {{- $mcpPath := include "kubecost.mcp.path" . }}
         {{- $mcpOauth := include "kubecost.mcp.oauthPrefix" . }}
         {{- /*

--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -666,7 +666,12 @@ finopsagent:
 ## server its own route instead, in which case the frontend stops proxying it.
 ##
 mcp:
-  enabled: true
+  ## mcp.enabled is omitted on purpose. Chart.yaml condition is
+  ## mcp.enabled,aggregator.enabled: the first boolean wins, otherwise the
+  ## subchart follows aggregator.enabled. Agent-only installs that only set
+  ## aggregator.enabled=false therefore skip MCP without a new flag.
+  ## Override with mcp.enabled: true or mcp.enabled: false.
+  ##
   ## The MCP server reads cost data through the Kubecost aggregator service.
   ## If Kubecost is deployed with SAML or OIDC authentication,
   ## the MCP server must be configured with its own OIDC configuration.


### PR DESCRIPTION
manual cp for failed cherry-pick bot


* Follow aggregator.enabled when mcp.enabled is unset

Helm cannot use templates as a subchart condition. Omitting mcp.enabled lets Chart.yaml fall through to aggregator.enabled so agent-only upgrades skip MCP without a new flag.

* fix: review follow-ups for mcp/follow-aggregator-enabled

- Rename validate script section header from 'Subchart is enabled by default' to 'Default-render behaviour (follows aggregator.enabled)' to reflect the new conditional-enable semantics.

- Add mcpEnabled=true and upstream mcpKubecost assertions to the mcp-forced-on test scenario (mirrors the existing aggregator-off assertions for symmetry).

- Normalize kubecost.mcp.enabled helper: collapse the fallthrough branches to inline style consistent with the explicit-bool branches. Functionally identical; trim markers already stripped the newlines.

* fix chart lock

* ci: add kubeconform renders for aggregator-follows-mcp scenarios

Add four kubeconform renders to validate-mcp-subchart.yml to cover all toggle combinations introduced by the mcp.enabled,aggregator.enabled condition:

- mcp-default: no mcp.enabled set, aggregator.enabled=true (default) — the MCP-follows-aggregator path that was never schema-validated before
- mcp-enabled: explicit mcp.enabled=true (existing backwards-compat path, now renamed for clarity)
- aggregator-off: aggregator.enabled=false, mcp.enabled unset — ensures the chart without MCP resources still produces valid K8s YAML
- mcp-forced-on: aggregator.enabled=false, mcp.enabled=true — the external-aggregator override path

Each render gets its own kubeconform step so failures are scoped to the exact scenario that broke.

* chore: update .gitignore to include .helm-render directory

## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->

## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
