### PR TITLE
Use latest curl image for basic healthcheck

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -1948,7 +1948,7 @@ extraObjects: []
 basicHealth:
   registry: docker.io
   repository: alpine/curl
-  tag: 8.17.0
+  tag: latest
 
 # -- Optional override for the image used for the HTTPRoute helm test (only when httpRoute.enabled)
 httprouteTest:


### PR DESCRIPTION
## Release Notes Headline

Updated the default value of `.Values.basicHealth.tag` from `8.17.0` to `latest`.

## Commentary for Reviewers

The latest version of `alpine/curl` is `8.22.0`, and `8.17.0` is being flagged for CVEs. It's used for an optional health check, and we already target a `latest` curl image for an optional opencost plugin elsewhere in the chart.

## Links to Issues or Tickets

<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks

<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
