### PR TITLE
3.3: document how to add external labels to finops chart from kubecost chart

### DIFF
--- a/kubecost/values.yaml
+++ b/kubecost/values.yaml
@@ -603,7 +603,7 @@ localStore:
 ## Collects kubernetes metrics and sends them to storage. Below are a subset of
 ## values from the finopsagent subchart that are most commonly changed.
 ## Ref: https://github.com/kubecost/finops-agent-chart/blob/main/charts/finops-agent/values.yaml
-##
+## Note: External labels are commented out by default. For configuration details, refer to the FinOps Agent chart documentation.
 finopsagent:
   enabled: true
   image:
@@ -655,6 +655,13 @@ finopsagent:
       gpuLabelValue: ""
       spotLabel: ""
       spotLabelValue: ""
+  # external:
+  #   nodeLabels:
+  #     configMapName: ""
+  #     namespace: ""
+  #     key: ""
+  #     route: ""
+
 
 ## The FinOps MCP server for Kubecost analytics. Below are a subset of values from
 ## the mcp-kubecost subchart that are most commonly changed.


### PR DESCRIPTION
## Release Notes Headline

<!-- Provide a one-sentence summary of the change. "N/A" if no user-facing change. -->
NR
## Commentary for Reviewers

<!-- Highlight key changes. If this PR depends on other PRs to be merged first, mention them here. -->
How-to add node label configuration in kubecost values.yaml

## Links to Issues or Tickets
https://apptio.atlassian.net/browse/KCM-6380
<!-- Use GitHub's closing keywords to link issues (e.g., "Closes #123"). Otherwise, "N/A". -->
<!-- Ref: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## User Impact and Risks
None
<!-- Describe the impact of this PR on users. What are the risks associated with merging this PR? -->

## Testing
Tested it in qa-eks3 cluster namespace alan-testbed

The values configuration passed is

```
global:
  acknowledged: true
  clusterId: alan-testbed
  federatedStorage:
    config: |-
      <Redacted>
clusterController:
  enabled: false
networkCosts:
  enabled: false
aggregator:
  enabled: true
  # fullImageName: "gcr.io/guestbook-227502/kubecost-cost-model:collection_feature_dbcache_0.02"
  aggregatorDbStorage:
    storageRequest: 50Gi
  deployMethod: statefulset
  logLevel: debug
  persistentConfigsStorage:
    storageRequest: 50Gi
  resources:
    limits:
      cpu: 10000m
      memory: 20Gi
    requests:
      cpu: 1000m
      memory: 10Gi
  retention10m: 0
  retention1d: 7
  retention1h: 49
  collections:
    cache:
      enabled: true
ingress:
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-http
  className: nginx
  enabled: true
  hosts:
  - alan-testbed.qa-eks3.kubecost.xyz
  tls:
  - hosts:
    - alan-testbed.qa-eks3.kubecost.xyz
    secretName: project-on-prem-tls
frontend:
  enabled: true
cloudCost:
  enabled: false
forecasting:
  enabled: false
finopsagent:
  enabled: true
  external:
    nodeLabels:
      configMapName: "external-labels-config"
      namespace: "external-label-test" 
      key: config.yaml
      route: metadata.externalLabels
localStore:
  enabled: false
mcp:
  enabled: false

```

Configmap applied 

```
>kubectl apply -n external-label-test -f - <<'EOF'             
apiVersion: v1
kind: ConfigMap
metadata:
  name: external-labels-config
data:
  config.yaml: |
    metadata:
      externalLabels:
        cluster: prod
        env: dev
        region: nam
EOF

```

the node asset has the label also the label is avail in filtering etc

<img width="847" height="1282" alt="Screenshot 2026-09-10 at 2 38 25 PM" src="https://github.com/user-attachments/assets/036978ea-e756-4601-807e-0d946426c50e" />

<!-- Describe the testing that was performed to verify the changes. -->

## Documentation Updates

<!-- If this PR requires updates to documentation, please provide the link to the PR here. -->
